### PR TITLE
Add IPFS config migration defaults

### DIFF
--- a/.changeset/warm-dots-serve.md
+++ b/.changeset/warm-dots-serve.md
@@ -1,0 +1,5 @@
+---
+"bgipfs": patch
+---
+
+Add IPFS daemon config migration defaults and expose an IPFS-only dry run mode.

--- a/.gitignore
+++ b/.gitignore
@@ -11,4 +11,5 @@ identity.json
 service.json
 htpasswd
 docker-compose.override.yml
+config-backup/
 .pnpm-store

--- a/packages/bgipfs/README.md
+++ b/packages/bgipfs/README.md
@@ -58,6 +58,12 @@ bgipfs cluster
 
 During cluster setup, the `cluster config` command will help you populate:
 
+To preview IPFS config migration changes without writing files:
+
+```bash
+bgipfs cluster config --mode ipfs --ipfs-dry-run
+```
+
 #### Environment Variables (.env)
 - `PEERNAME` - Peer name in the IPFS Cluster
 - `SECRET` - Cluster secret

--- a/packages/bgipfs/src/commands/cluster/config/index.ts
+++ b/packages/bgipfs/src/commands/cluster/config/index.ts
@@ -7,17 +7,31 @@ import {z} from 'zod'
 
 import {BaseCommand} from '../../../base-command.js'
 import {AuthService} from '../../../lib/auth-service.js'
+import {getBgipfsIpfsConfigPolicy} from '../../../lib/bgipfs-owned-keys.js'
 import {EnvManager} from '../../../lib/env-manager.js'
 import {baseSchema} from '../../../lib/env-schema.js'
+import {
+  type IpfsConfigChange,
+  backupIpfsConfig,
+  computeIpfsConfigChanges,
+  mergeIpfsConfig,
+  readIpfsConfig,
+  readIpfsRepoVersion,
+  writeIpfsConfig,
+} from '../../../lib/ipfs-config.js'
 import {checkDocker, checkRunningContainers} from '../../../lib/system.js'
 import {TemplateManager} from '../../../lib/templates.js'
 
-type ConfigMode = 'all' | 'environment' | 'initialization' | 'templates'
+type ConfigMode = 'all' | 'environment' | 'initialization' | 'ipfs' | 'templates'
 
 export default class Init extends BaseCommand {
   static description = 'Set up the necessary configuration for IPFS Cluster'
 
   static flags = {
+    'dry-run': Flags.boolean({
+      default: false,
+      description: 'Preview IPFS config changes without writing them',
+    }),
     force: Flags.boolean({
       char: 'f',
       default: false,
@@ -28,7 +42,7 @@ export default class Init extends BaseCommand {
       char: 'm',
       default: 'all',
       description: 'Configuration mode to run',
-      options: ['templates', 'environment', 'initialization', 'all'],
+      options: ['templates', 'environment', 'initialization', 'ipfs', 'all'],
     }),
   }
 
@@ -42,13 +56,14 @@ export default class Init extends BaseCommand {
     const templates = new TemplateManager()
 
     const mode = flags.mode as ConfigMode
-    const shouldRunTemplates = mode === 'all' || mode === 'templates'
-    const shouldRunEnvironment = mode === 'all' || mode === 'environment'
-    const shouldRunInitialization = mode === 'all' || mode === 'initialization'
+    const shouldRunTemplates = this.modeIncludes(mode, 'templates')
+    const shouldRunEnvironment = this.modeIncludes(mode, 'environment')
+    const shouldRunInitialization = this.modeIncludes(mode, 'initialization')
+    const shouldRunIpfs = this.modeIncludes(mode, 'ipfs')
 
-    // Check for running containers only if we need to initialize
-    await checkDocker()
+    // Docker is only required for the initialization flow.
     if (shouldRunInitialization) {
+      await checkDocker()
       const running = await checkRunningContainers()
       if (running.length > 0) {
         if (flags.force) {
@@ -81,6 +96,11 @@ export default class Init extends BaseCommand {
         await this.initializeCluster(flags.force)
       }
 
+      // Step 4: IPFS config
+      if (shouldRunIpfs) {
+        await this.configureIpfsConfig(flags.force, flags['dry-run'])
+      }
+
       this.logSuccess('Configuration completed successfully!')
       if (shouldRunTemplates) {
         this.logInfo('Your docker-compose files have been updated')
@@ -93,7 +113,10 @@ export default class Init extends BaseCommand {
       if (shouldRunInitialization) {
         this.logInfo('Your cluster identity is in identity.json')
         this.logInfo('Your cluster service configuration is in service.json')
+        this.logInfo('Your IPFS daemon configuration is in ipfs.config.json')
         this.logInfo('You can now start the cluster with `bgipfs cluster start`')
+      } else if (shouldRunIpfs) {
+        this.logInfo('Restart the cluster with `bgipfs cluster restart` for IPFS config changes to take effect')
       } else if (shouldRunTemplates || shouldRunEnvironment) {
         this.logInfo('You may need to restart the cluster with `bgipfs cluster restart` for changes to take effect')
       }
@@ -182,6 +205,43 @@ export default class Init extends BaseCommand {
     ]
   }
 
+  private async configureIpfsConfig(force: boolean, dryRun: boolean): Promise<void> {
+    this.logInfo('Checking IPFS daemon configuration...')
+
+    const config = await readIpfsConfig()
+    const repoVersion = await readIpfsRepoVersion()
+    const policy = getBgipfsIpfsConfigPolicy(config, repoVersion)
+    const changes = computeIpfsConfigChanges(config, policy.ownedKeys, policy.removedKeys)
+
+    if (changes.length === 0) {
+      this.logSuccess('ipfs.config.json is already current')
+      return
+    }
+
+    this.logInfo('The following bgipfs-owned IPFS config keys will be updated:')
+    this.log(this.formatIpfsConfigChanges(changes))
+
+    if (dryRun) {
+      this.logInfo('Dry run complete; no files were changed')
+      return
+    }
+
+    if (!force) {
+      const shouldUpdate = await this.confirm('Apply these IPFS config changes?')
+      if (!shouldUpdate) {
+        this.logInfo('IPFS config update cancelled')
+        return
+      }
+    }
+
+    const backupPath = await backupIpfsConfig()
+    const merged = mergeIpfsConfig(config, policy.ownedKeys, policy.removedKeys)
+    await writeIpfsConfig(merged)
+
+    this.logSuccess(`Backed up ipfs.config.json to ${backupPath}`)
+    this.logSuccess('IPFS config updated')
+  }
+
   private async copyFileIfNotEmpty(source: string, dest: string): Promise<boolean> {
     const stats = await fs.stat(source)
     if (stats.size === 0) {
@@ -239,6 +299,21 @@ export default class Init extends BaseCommand {
 
     this.logInfo(`Using existing ${description}`)
     return true
+  }
+
+  private formatConfigValue(value: unknown): string {
+    return value === undefined ? '<unset>' : JSON.stringify(value)
+  }
+
+  private formatIpfsConfigChanges(changes: IpfsConfigChange[]): string {
+    return changes
+      .map(
+        ({key, nextValue, previousValue, type}) =>
+          type === 'remove'
+            ? `- ${key}: remove ${this.formatConfigValue(previousValue)}`
+            : `- ${key}: ${this.formatConfigValue(previousValue)} -> ${this.formatConfigValue(nextValue)}`,
+      )
+      .join('\n')
   }
 
   private generateSecret(): string {
@@ -370,6 +445,10 @@ export default class Init extends BaseCommand {
 
       throw error
     }
+  }
+
+  private modeIncludes(mode: ConfigMode, target: Exclude<ConfigMode, 'all'>): boolean {
+    return mode === 'all' || mode === target || (mode === 'initialization' && target === 'ipfs')
   }
 
   private async readCurrentEnv(env: EnvManager): Promise<{

--- a/packages/bgipfs/src/commands/cluster/config/index.ts
+++ b/packages/bgipfs/src/commands/cluster/config/index.ts
@@ -28,15 +28,15 @@ export default class Init extends BaseCommand {
   static description = 'Set up the necessary configuration for IPFS Cluster'
 
   static flags = {
-    'dry-run': Flags.boolean({
-      default: false,
-      description: 'Preview IPFS config changes without writing them',
-    }),
     force: Flags.boolean({
       char: 'f',
       default: false,
       description:
         'Force configuration: stop running containers, overwrite templates, and skip prompts if valid env exists',
+    }),
+    'ipfs-dry-run': Flags.boolean({
+      default: false,
+      description: 'Preview IPFS config changes without writing them',
     }),
     mode: Flags.string({
       char: 'm',
@@ -56,6 +56,11 @@ export default class Init extends BaseCommand {
     const templates = new TemplateManager()
 
     const mode = flags.mode as ConfigMode
+    if (flags['ipfs-dry-run'] && mode !== 'ipfs') {
+      this.logError('--ipfs-dry-run only applies with --mode ipfs')
+      return
+    }
+
     const shouldRunTemplates = this.modeIncludes(mode, 'templates')
     const shouldRunEnvironment = this.modeIncludes(mode, 'environment')
     const shouldRunInitialization = this.modeIncludes(mode, 'initialization')
@@ -98,7 +103,7 @@ export default class Init extends BaseCommand {
 
       // Step 4: IPFS config
       if (shouldRunIpfs) {
-        await this.configureIpfsConfig(flags.force, flags['dry-run'])
+        await this.configureIpfsConfig(flags.force, flags['ipfs-dry-run'])
       }
 
       this.logSuccess('Configuration completed successfully!')

--- a/packages/bgipfs/src/lib/bgipfs-owned-keys.ts
+++ b/packages/bgipfs/src/lib/bgipfs-owned-keys.ts
@@ -4,6 +4,7 @@ export interface BgipfsIpfsConfigPolicy {
 }
 
 const COMMON_OWNED_KEYS: Record<string, unknown> = {
+  'Gateway.NoFetch': true,
   'Routing.AcceleratedDHTClient': true,
   'Routing.Type': 'dht',
 }

--- a/packages/bgipfs/src/lib/bgipfs-owned-keys.ts
+++ b/packages/bgipfs/src/lib/bgipfs-owned-keys.ts
@@ -1,0 +1,40 @@
+export interface BgipfsIpfsConfigPolicy {
+  ownedKeys: Record<string, unknown>
+  removedKeys: string[]
+}
+
+const COMMON_OWNED_KEYS: Record<string, unknown> = {
+  'Routing.AcceleratedDHTClient': true,
+  'Routing.Type': 'dht',
+}
+
+export const getBgipfsIpfsConfigPolicy = (
+  config: Record<string, unknown>,
+  repoVersion?: number,
+): BgipfsIpfsConfigPolicy => {
+  const usesProvideConfig =
+    repoVersion === undefined ? hasObject(config, 'Provide') || !hasObject(config, 'Reprovider') : repoVersion >= 18
+
+  if (usesProvideConfig) {
+    return {
+      ownedKeys: {
+        'Provide.Strategy': 'roots',
+        ...COMMON_OWNED_KEYS,
+      },
+      removedKeys: ['Reprovider'],
+    }
+  }
+
+  return {
+    ownedKeys: {
+      'Reprovider.Strategy': 'roots',
+      ...COMMON_OWNED_KEYS,
+    },
+    removedKeys: [],
+  }
+}
+
+const hasObject = (config: Record<string, unknown>, key: string): boolean => {
+  const value = config[key]
+  return Boolean(value && typeof value === 'object' && !Array.isArray(value))
+}

--- a/packages/bgipfs/src/lib/ipfs-config.ts
+++ b/packages/bgipfs/src/lib/ipfs-config.ts
@@ -1,0 +1,138 @@
+import {promises as fs} from 'node:fs'
+import path from 'node:path'
+
+export interface IpfsConfigChange {
+  key: string
+  nextValue: unknown
+  previousValue: unknown
+  type: 'remove' | 'set'
+}
+
+export const computeIpfsConfigChanges = (
+  config: Record<string, unknown>,
+  ownedKeys: Record<string, unknown>,
+  removedKeys: string[] = [],
+): IpfsConfigChange[] =>
+  [
+    ...removedKeys
+      .filter((key) => getNestedValue(config, key) !== undefined)
+      .map((key) => ({
+        key,
+        nextValue: undefined,
+        previousValue: getNestedValue(config, key),
+        type: 'remove' as const,
+      })),
+    ...Object.entries(ownedKeys)
+    .filter(([key, nextValue]) => !isEqual(getNestedValue(config, key), nextValue))
+    .map(([key, nextValue]) => ({
+      key,
+      nextValue,
+      previousValue: getNestedValue(config, key),
+      type: 'set' as const,
+    })),
+  ]
+
+export const mergeIpfsConfig = (
+  config: Record<string, unknown>,
+  ownedKeys: Record<string, unknown>,
+  removedKeys: string[] = [],
+): Record<string, unknown> => {
+  const merged = structuredClone(config)
+
+  for (const key of removedKeys) {
+    deleteNestedValue(merged, key)
+  }
+
+  for (const [key, value] of Object.entries(ownedKeys)) {
+    setNestedValue(merged, key, value)
+  }
+
+  return merged
+}
+
+export const readIpfsConfig = async (configPath = 'ipfs.config.json'): Promise<Record<string, unknown>> => {
+  const content = await fs.readFile(configPath, 'utf8')
+  const parsed = JSON.parse(content) as unknown
+
+  if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
+    throw new Error(`${configPath} must contain a JSON object`)
+  }
+
+  return parsed as Record<string, unknown>
+}
+
+export const readIpfsRepoVersion = async (versionPath = 'data/ipfs/version'): Promise<number | undefined> => {
+  try {
+    const content = await fs.readFile(versionPath, 'utf8')
+    const version = Number.parseInt(content.trim(), 10)
+    return Number.isNaN(version) ? undefined : version
+  } catch {
+    return undefined
+  }
+}
+
+export const backupIpfsConfig = async (
+  configPath = 'ipfs.config.json',
+  backupDir = 'config-backup',
+): Promise<string> => {
+  await fs.mkdir(backupDir, {recursive: true})
+  const timestamp = new Date().toISOString().replaceAll(/[.:]/g, '-')
+  const backupPath = path.join(backupDir, `${path.basename(configPath)}.${timestamp}`)
+  await fs.copyFile(configPath, backupPath)
+  return backupPath
+}
+
+export const writeIpfsConfig = async (
+  config: Record<string, unknown>,
+  configPath = 'ipfs.config.json',
+): Promise<void> => {
+  await fs.writeFile(configPath, JSON.stringify(config, null, 2) + '\n')
+}
+
+const getNestedValue = (config: Record<string, unknown>, key: string): unknown => {
+  let current: unknown = config
+
+  for (const segment of key.split('.')) {
+    if (!current || typeof current !== 'object' || Array.isArray(current)) {
+      return undefined
+    }
+
+    current = (current as Record<string, unknown>)[segment]
+  }
+
+  return current
+}
+
+const setNestedValue = (config: Record<string, unknown>, key: string, value: unknown): void => {
+  const segments = key.split('.')
+  let current = config
+
+  for (const segment of segments.slice(0, -1)) {
+    const next = current[segment]
+    if (!next || typeof next !== 'object' || Array.isArray(next)) {
+      current[segment] = {}
+    }
+
+    current = current[segment] as Record<string, unknown>
+  }
+
+  current[segments.at(-1) as string] = value
+}
+
+const deleteNestedValue = (config: Record<string, unknown>, key: string): void => {
+  const segments = key.split('.')
+  let current: Record<string, unknown> = config
+
+  for (const segment of segments.slice(0, -1)) {
+    const next = current[segment]
+    if (!next || typeof next !== 'object' || Array.isArray(next)) {
+      return
+    }
+
+    current = next as Record<string, unknown>
+  }
+
+  delete current[segments.at(-1) as string]
+}
+
+const isEqual = (left: unknown, right: unknown): boolean => JSON.stringify(left) === JSON.stringify(right)

--- a/packages/bgipfs/test/lib/bgipfs-owned-keys.test.ts
+++ b/packages/bgipfs/test/lib/bgipfs-owned-keys.test.ts
@@ -15,6 +15,7 @@ describe('bgipfs-owned-keys', () => {
 
     expect(policy).to.deep.equal({
       ownedKeys: {
+        'Gateway.NoFetch': true,
         'Reprovider.Strategy': 'roots',
         'Routing.AcceleratedDHTClient': true,
         'Routing.Type': 'dht',
@@ -35,6 +36,7 @@ describe('bgipfs-owned-keys', () => {
 
     expect(policy).to.deep.equal({
       ownedKeys: {
+        'Gateway.NoFetch': true,
         'Provide.Strategy': 'roots',
         'Routing.AcceleratedDHTClient': true,
         'Routing.Type': 'dht',
@@ -52,6 +54,7 @@ describe('bgipfs-owned-keys', () => {
       }),
     ).to.deep.equal({
       ownedKeys: {
+        'Gateway.NoFetch': true,
         'Reprovider.Strategy': 'roots',
         'Routing.AcceleratedDHTClient': true,
         'Routing.Type': 'dht',
@@ -67,6 +70,7 @@ describe('bgipfs-owned-keys', () => {
       }),
     ).to.deep.equal({
       ownedKeys: {
+        'Gateway.NoFetch': true,
         'Provide.Strategy': 'roots',
         'Routing.AcceleratedDHTClient': true,
         'Routing.Type': 'dht',

--- a/packages/bgipfs/test/lib/bgipfs-owned-keys.test.ts
+++ b/packages/bgipfs/test/lib/bgipfs-owned-keys.test.ts
@@ -1,0 +1,77 @@
+import {expect} from 'chai'
+
+import {getBgipfsIpfsConfigPolicy} from '../../src/lib/bgipfs-owned-keys.js'
+
+describe('bgipfs-owned-keys', () => {
+  it('uses legacy Reprovider keys for repo versions before 18', () => {
+    const policy = getBgipfsIpfsConfigPolicy(
+      {
+        Reprovider: {
+          Strategy: 'all',
+        },
+      },
+      17,
+    )
+
+    expect(policy).to.deep.equal({
+      ownedKeys: {
+        'Reprovider.Strategy': 'roots',
+        'Routing.AcceleratedDHTClient': true,
+        'Routing.Type': 'dht',
+      },
+      removedKeys: [],
+    })
+  })
+
+  it('uses current Provide keys and removes Reprovider for repo version 18+', () => {
+    const policy = getBgipfsIpfsConfigPolicy(
+      {
+        Reprovider: {
+          Strategy: 'roots',
+        },
+      },
+      18,
+    )
+
+    expect(policy).to.deep.equal({
+      ownedKeys: {
+        'Provide.Strategy': 'roots',
+        'Routing.AcceleratedDHTClient': true,
+        'Routing.Type': 'dht',
+      },
+      removedKeys: ['Reprovider'],
+    })
+  })
+
+  it('falls back to config shape when repo version is unavailable', () => {
+    expect(
+      getBgipfsIpfsConfigPolicy({
+        Reprovider: {
+          Strategy: 'all',
+        },
+      }),
+    ).to.deep.equal({
+      ownedKeys: {
+        'Reprovider.Strategy': 'roots',
+        'Routing.AcceleratedDHTClient': true,
+        'Routing.Type': 'dht',
+      },
+      removedKeys: [],
+    })
+
+    expect(
+      getBgipfsIpfsConfigPolicy({
+        Provide: {
+          Strategy: 'all',
+        },
+      }),
+    ).to.deep.equal({
+      ownedKeys: {
+        'Provide.Strategy': 'roots',
+        'Routing.AcceleratedDHTClient': true,
+        'Routing.Type': 'dht',
+      },
+      removedKeys: ['Reprovider'],
+    })
+  })
+})

--- a/packages/bgipfs/test/lib/ipfs-config.test.ts
+++ b/packages/bgipfs/test/lib/ipfs-config.test.ts
@@ -1,0 +1,355 @@
+import {expect} from 'chai'
+import {mkdtemp, readFile, readdir, rm, writeFile} from 'node:fs/promises'
+import {tmpdir} from 'node:os'
+import path from 'node:path'
+
+import {
+  backupIpfsConfig,
+  computeIpfsConfigChanges,
+  mergeIpfsConfig,
+  readIpfsConfig,
+  readIpfsRepoVersion,
+  writeIpfsConfig,
+} from '../../src/lib/ipfs-config.js'
+
+describe('ipfs-config', () => {
+  let workdir: string
+
+  beforeEach(async () => {
+    workdir = await mkdtemp(path.join(tmpdir(), 'bgipfs-ipfs-config-'))
+  })
+
+  afterEach(async () => {
+    await rm(workdir, {force: true, recursive: true})
+  })
+
+  it('computes changes for nested dotted keys', () => {
+    const config = {
+      Reprovider: {
+        Strategy: 'all',
+      },
+      Routing: {
+        Type: 'auto',
+      },
+    }
+
+    const changes = computeIpfsConfigChanges(config, {
+      'Provide.Strategy': 'roots',
+      'Routing.AcceleratedDHTClient': true,
+      'Routing.Type': 'dht',
+    })
+
+    expect(changes).to.deep.equal([
+      {
+        key: 'Provide.Strategy',
+        nextValue: 'roots',
+        previousValue: undefined,
+        type: 'set',
+      },
+      {
+        key: 'Routing.AcceleratedDHTClient',
+        nextValue: true,
+        previousValue: undefined,
+        type: 'set',
+      },
+      {
+        key: 'Routing.Type',
+        nextValue: 'dht',
+        previousValue: 'auto',
+        type: 'set',
+      },
+    ])
+  })
+
+  it('computes removals for deprecated keys', () => {
+    const config = {
+      Reprovider: {
+        Strategy: 'roots',
+      },
+      Routing: {
+        Type: 'dht',
+      },
+    }
+
+    const changes = computeIpfsConfigChanges(
+      config,
+      {
+        'Routing.Type': 'dht',
+      },
+      ['Reprovider'],
+    )
+
+    expect(changes).to.deep.equal([
+      {
+        key: 'Reprovider',
+        nextValue: undefined,
+        previousValue: {
+          Strategy: 'roots',
+        },
+        type: 'remove',
+      },
+    ])
+  })
+
+  it('removes deprecated keys while merging owned keys', () => {
+    const config = {
+      Reprovider: {
+        Strategy: 'all',
+      },
+      Routing: {
+        Type: 'auto',
+      },
+    }
+
+    const merged = mergeIpfsConfig(
+      config,
+      {
+        'Provide.Strategy': 'roots',
+        'Routing.Type': 'dht',
+      },
+      ['Reprovider'],
+    )
+
+    expect(merged).to.deep.equal({
+      Provide: {
+        Strategy: 'roots',
+      },
+      Routing: {
+        Type: 'dht',
+      },
+    })
+  })
+
+  it('does not report current keys as changes', () => {
+    const config = {
+      Provide: {
+        Strategy: 'roots',
+      },
+      Routing: {
+        AcceleratedDHTClient: true,
+        Type: 'dht',
+      },
+    }
+
+    const changes = computeIpfsConfigChanges(config, {
+      'Provide.Strategy': 'roots',
+      'Routing.AcceleratedDHTClient': true,
+      'Routing.Type': 'dht',
+    })
+
+    expect(changes).to.deep.equal([])
+  })
+
+  it('does not report absent removals as changes', () => {
+    const changes = computeIpfsConfigChanges(
+      {
+        Routing: {
+          Type: 'dht',
+        },
+      },
+      {},
+      ['Reprovider'],
+    )
+
+    expect(changes).to.deep.equal([])
+  })
+
+  it('computes current reprovider strategy changes for legacy configs', () => {
+    const config = {
+      Reprovider: {
+        Strategy: 'all',
+      },
+      Routing: {
+        Type: 'auto',
+      },
+    }
+
+    const changes = computeIpfsConfigChanges(
+      config,
+      {
+        'Provide.Strategy': 'roots',
+        'Routing.Type': 'dht',
+      },
+      ['Reprovider'],
+    )
+
+    expect(changes).to.deep.equal([
+      {
+        key: 'Reprovider',
+        nextValue: undefined,
+        previousValue: {
+          Strategy: 'all',
+        },
+        type: 'remove',
+      },
+      {
+        key: 'Provide.Strategy',
+        nextValue: 'roots',
+        previousValue: undefined,
+        type: 'set',
+      },
+      {
+        key: 'Routing.Type',
+        nextValue: 'dht',
+        previousValue: 'auto',
+        type: 'set',
+      },
+    ])
+  })
+
+  it('computes changes for nested dotted keys with existing provide config', () => {
+    const config = {
+      Provide: {
+        Strategy: 'all',
+      },
+      Routing: {
+        Type: 'auto',
+      },
+    }
+
+    const changes = computeIpfsConfigChanges(config, {
+      'Provide.Strategy': 'roots',
+      'Routing.AcceleratedDHTClient': true,
+      'Routing.Type': 'dht',
+    })
+
+    expect(changes).to.deep.equal([
+      {
+        key: 'Provide.Strategy',
+        nextValue: 'roots',
+        previousValue: 'all',
+        type: 'set',
+      },
+      {
+        key: 'Routing.AcceleratedDHTClient',
+        nextValue: true,
+        previousValue: undefined,
+        type: 'set',
+      },
+      {
+        key: 'Routing.Type',
+        nextValue: 'dht',
+        previousValue: 'auto',
+        type: 'set',
+      },
+    ])
+  })
+
+  it('computes changes for legacy nested dotted keys', () => {
+    const config = {
+      Reprovider: {
+        Strategy: 'all',
+      },
+      Routing: {
+        Type: 'auto',
+      },
+    }
+
+    const changes = computeIpfsConfigChanges(config, {
+      'Reprovider.Strategy': 'roots',
+      'Routing.AcceleratedDHTClient': true,
+      'Routing.Type': 'dht',
+    })
+
+    expect(changes).to.deep.equal([
+      {
+        key: 'Reprovider.Strategy',
+        nextValue: 'roots',
+        previousValue: 'all',
+        type: 'set',
+      },
+      {
+        key: 'Routing.AcceleratedDHTClient',
+        nextValue: true,
+        previousValue: undefined,
+        type: 'set',
+      },
+      {
+        key: 'Routing.Type',
+        nextValue: 'dht',
+        previousValue: 'auto',
+        type: 'set',
+      },
+    ])
+  })
+
+  it('merges owned keys while preserving unrelated config', () => {
+    const config = {
+      Addresses: {
+        Swarm: ['/ip4/0.0.0.0/tcp/4001'],
+      },
+      Identity: {
+        PeerID: 'peer-id',
+        PrivKey: 'private-key',
+      },
+      Routing: {
+        Type: 'auto',
+      },
+    }
+
+    const merged = mergeIpfsConfig(config, {
+      'Provide.Strategy': 'roots',
+      'Routing.AcceleratedDHTClient': true,
+      'Routing.Type': 'dht',
+    })
+
+    expect(merged).to.deep.equal({
+      Addresses: {
+        Swarm: ['/ip4/0.0.0.0/tcp/4001'],
+      },
+      Identity: {
+        PeerID: 'peer-id',
+        PrivKey: 'private-key',
+      },
+      Provide: {
+        Strategy: 'roots',
+      },
+      Routing: {
+        AcceleratedDHTClient: true,
+        Type: 'dht',
+      },
+    })
+    expect(config).to.deep.equal({
+      Addresses: {
+        Swarm: ['/ip4/0.0.0.0/tcp/4001'],
+      },
+      Identity: {
+        PeerID: 'peer-id',
+        PrivKey: 'private-key',
+      },
+      Routing: {
+        Type: 'auto',
+      },
+    })
+  })
+
+  it('backs up and writes ipfs config JSON', async () => {
+    const configPath = path.join(workdir, 'ipfs.config.json')
+    const backupDir = path.join(workdir, 'config-backup')
+    await writeFile(configPath, '{"Routing":{"Type":"auto"}}\n')
+
+    const backupPath = await backupIpfsConfig(configPath, backupDir)
+    await writeIpfsConfig({Routing: {Type: 'dht'}}, configPath)
+
+    const backupFiles = await readdir(backupDir)
+    expect(backupFiles).to.have.length(1)
+    expect(backupPath).to.equal(path.join(backupDir, backupFiles[0]))
+    expect(await readFile(backupPath, 'utf8')).to.equal('{"Routing":{"Type":"auto"}}\n')
+    expect(await readIpfsConfig(configPath)).to.deep.equal({Routing: {Type: 'dht'}})
+  })
+
+  it('reads repo version when present', async () => {
+    const versionPath = path.join(workdir, 'version')
+    await writeFile(versionPath, '18\n')
+
+    expect(await readIpfsRepoVersion(versionPath)).to.equal(18)
+  })
+
+  it('returns undefined when repo version is unavailable or invalid', async () => {
+    const versionPath = path.join(workdir, 'version')
+    await writeFile(versionPath, 'not-a-number\n')
+
+    expect(await readIpfsRepoVersion(versionPath)).to.equal(undefined)
+    expect(await readIpfsRepoVersion(path.join(workdir, 'missing'))).to.equal(undefined)
+  })
+})


### PR DESCRIPTION
## Summary
- add `bgipfs cluster config --mode ipfs` to merge bgipfs-owned Kubo config keys into existing `ipfs.config.json`
- apply discoverability defaults during initialization and existing-cluster migration
- choose `Reprovider.Strategy` for legacy repo versions and `Provide.Strategy` for repo v18+ configs
- set `Gateway.NoFetch=true` so the gateway only serves local content instead of fetching arbitrary CIDs
- preserve unrelated Kubo config and back up before writing

## Testing
- `pnpm --filter bgipfs test`
- `pnpm --filter bgipfs build`
- initialized and started a disposable local cluster pinned to `ipfs/kubo:v0.32.1`; verified `Reprovider.Strategy=roots`, `Routing.Type=dht`, and `Routing.AcceleratedDHTClient=true`
- verified current repo-version path uses `Provide.Strategy=roots` and removes deprecated `Reprovider`
