### PR TITLE
Refine IPFS provider defaults

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -4,7 +4,7 @@
   "commit": false,
   "fixed": [],
   "linked": [],
-  "access": "restricted",
+  "access": "public",
   "baseBranch": "main",
   "updateInternalDependencies": "patch",
   "ignore": []

--- a/.changeset/soft-buckets-serve.md
+++ b/.changeset/soft-buckets-serve.md
@@ -1,0 +1,5 @@
+---
+"bgipfs": patch
+---
+
+Remove accelerated DHT client from default IPFS config and use entity-level provider records for current Kubo repos.

--- a/packages/bgipfs/src/lib/bgipfs-owned-keys.ts
+++ b/packages/bgipfs/src/lib/bgipfs-owned-keys.ts
@@ -5,7 +5,6 @@ export interface BgipfsIpfsConfigPolicy {
 
 const COMMON_OWNED_KEYS: Record<string, unknown> = {
   'Gateway.NoFetch': true,
-  'Routing.AcceleratedDHTClient': true,
   'Routing.Type': 'dht',
 }
 
@@ -19,7 +18,7 @@ export const getBgipfsIpfsConfigPolicy = (
   if (usesProvideConfig) {
     return {
       ownedKeys: {
-        'Provide.Strategy': 'roots',
+        'Provide.Strategy': 'pinned+entities',
         ...COMMON_OWNED_KEYS,
       },
       removedKeys: ['Reprovider'],

--- a/packages/bgipfs/test/lib/bgipfs-owned-keys.test.ts
+++ b/packages/bgipfs/test/lib/bgipfs-owned-keys.test.ts
@@ -17,7 +17,6 @@ describe('bgipfs-owned-keys', () => {
       ownedKeys: {
         'Gateway.NoFetch': true,
         'Reprovider.Strategy': 'roots',
-        'Routing.AcceleratedDHTClient': true,
         'Routing.Type': 'dht',
       },
       removedKeys: [],
@@ -37,8 +36,7 @@ describe('bgipfs-owned-keys', () => {
     expect(policy).to.deep.equal({
       ownedKeys: {
         'Gateway.NoFetch': true,
-        'Provide.Strategy': 'roots',
-        'Routing.AcceleratedDHTClient': true,
+        'Provide.Strategy': 'pinned+entities',
         'Routing.Type': 'dht',
       },
       removedKeys: ['Reprovider'],
@@ -56,7 +54,6 @@ describe('bgipfs-owned-keys', () => {
       ownedKeys: {
         'Gateway.NoFetch': true,
         'Reprovider.Strategy': 'roots',
-        'Routing.AcceleratedDHTClient': true,
         'Routing.Type': 'dht',
       },
       removedKeys: [],
@@ -71,8 +68,7 @@ describe('bgipfs-owned-keys', () => {
     ).to.deep.equal({
       ownedKeys: {
         'Gateway.NoFetch': true,
-        'Provide.Strategy': 'roots',
-        'Routing.AcceleratedDHTClient': true,
+        'Provide.Strategy': 'pinned+entities',
         'Routing.Type': 'dht',
       },
       removedKeys: ['Reprovider'],

--- a/packages/bgipfs/test/lib/ipfs-config.test.ts
+++ b/packages/bgipfs/test/lib/ipfs-config.test.ts
@@ -34,21 +34,14 @@ describe('ipfs-config', () => {
     }
 
     const changes = computeIpfsConfigChanges(config, {
-      'Provide.Strategy': 'roots',
-      'Routing.AcceleratedDHTClient': true,
+      'Provide.Strategy': 'pinned+entities',
       'Routing.Type': 'dht',
     })
 
     expect(changes).to.deep.equal([
       {
         key: 'Provide.Strategy',
-        nextValue: 'roots',
-        previousValue: undefined,
-        type: 'set',
-      },
-      {
-        key: 'Routing.AcceleratedDHTClient',
-        nextValue: true,
+        nextValue: 'pinned+entities',
         previousValue: undefined,
         type: 'set',
       },
@@ -104,7 +97,7 @@ describe('ipfs-config', () => {
     const merged = mergeIpfsConfig(
       config,
       {
-        'Provide.Strategy': 'roots',
+        'Provide.Strategy': 'pinned+entities',
         'Routing.Type': 'dht',
       },
       ['Reprovider'],
@@ -112,7 +105,7 @@ describe('ipfs-config', () => {
 
     expect(merged).to.deep.equal({
       Provide: {
-        Strategy: 'roots',
+        Strategy: 'pinned+entities',
       },
       Routing: {
         Type: 'dht',
@@ -123,17 +116,15 @@ describe('ipfs-config', () => {
   it('does not report current keys as changes', () => {
     const config = {
       Provide: {
-        Strategy: 'roots',
+        Strategy: 'pinned+entities',
       },
       Routing: {
-        AcceleratedDHTClient: true,
         Type: 'dht',
       },
     }
 
     const changes = computeIpfsConfigChanges(config, {
-      'Provide.Strategy': 'roots',
-      'Routing.AcceleratedDHTClient': true,
+      'Provide.Strategy': 'pinned+entities',
       'Routing.Type': 'dht',
     })
 
@@ -167,7 +158,7 @@ describe('ipfs-config', () => {
     const changes = computeIpfsConfigChanges(
       config,
       {
-        'Provide.Strategy': 'roots',
+        'Provide.Strategy': 'pinned+entities',
         'Routing.Type': 'dht',
       },
       ['Reprovider'],
@@ -184,7 +175,7 @@ describe('ipfs-config', () => {
       },
       {
         key: 'Provide.Strategy',
-        nextValue: 'roots',
+        nextValue: 'pinned+entities',
         previousValue: undefined,
         type: 'set',
       },
@@ -208,22 +199,15 @@ describe('ipfs-config', () => {
     }
 
     const changes = computeIpfsConfigChanges(config, {
-      'Provide.Strategy': 'roots',
-      'Routing.AcceleratedDHTClient': true,
+      'Provide.Strategy': 'pinned+entities',
       'Routing.Type': 'dht',
     })
 
     expect(changes).to.deep.equal([
       {
         key: 'Provide.Strategy',
-        nextValue: 'roots',
+        nextValue: 'pinned+entities',
         previousValue: 'all',
-        type: 'set',
-      },
-      {
-        key: 'Routing.AcceleratedDHTClient',
-        nextValue: true,
-        previousValue: undefined,
         type: 'set',
       },
       {
@@ -247,7 +231,6 @@ describe('ipfs-config', () => {
 
     const changes = computeIpfsConfigChanges(config, {
       'Reprovider.Strategy': 'roots',
-      'Routing.AcceleratedDHTClient': true,
       'Routing.Type': 'dht',
     })
 
@@ -256,12 +239,6 @@ describe('ipfs-config', () => {
         key: 'Reprovider.Strategy',
         nextValue: 'roots',
         previousValue: 'all',
-        type: 'set',
-      },
-      {
-        key: 'Routing.AcceleratedDHTClient',
-        nextValue: true,
-        previousValue: undefined,
         type: 'set',
       },
       {
@@ -288,8 +265,7 @@ describe('ipfs-config', () => {
     }
 
     const merged = mergeIpfsConfig(config, {
-      'Provide.Strategy': 'roots',
-      'Routing.AcceleratedDHTClient': true,
+      'Provide.Strategy': 'pinned+entities',
       'Routing.Type': 'dht',
     })
 
@@ -302,10 +278,9 @@ describe('ipfs-config', () => {
         PrivKey: 'private-key',
       },
       Provide: {
-        Strategy: 'roots',
+        Strategy: 'pinned+entities',
       },
       Routing: {
-        AcceleratedDHTClient: true,
         Type: 'dht',
       },
     })


### PR DESCRIPTION
## Summary
- remove `Routing.AcceleratedDHTClient` from bgipfs-owned IPFS config defaults
- use `Provide.Strategy=pinned+entities` for current Kubo repo configs
- keep legacy Kubo repo configs on `Reprovider.Strategy=roots`
- set changesets publish access to public for unscoped packages

## Testing
- `pnpm --filter bgipfs test`
- `pnpm --filter bgipfs build`
- dry-ran against the local Kubo `0.32.1` test cluster; config stayed current on the legacy path
- smoke-tested a repo v18 temp config; migration wrote `Provide.Strategy=pinned+entities`, removed `Reprovider`, and did not set accelerated DHT
