### PR TITLE
Improve bgipfs cluster update path

### DIFF
--- a/packages/bgipfs/README.md
+++ b/packages/bgipfs/README.md
@@ -129,10 +129,11 @@ bgipfs cluster update --ipfs-version v0.41.0 --cluster-version v1.1.6 --traefik-
 The update process:
 1. Checks Docker Compose and the local compose file
 2. Creates a backup of configuration files (unless --no-backup is specified). Use `--backup-data` or a volume snapshot for IPFS data.
-3. Updates managed image tags in `docker-compose.yml` (unless `--skip-compose-update` is specified)
-4. Pulls the requested Docker images and reports image changes
-5. Restarts or starts services with the new images
-6. Verifies IPFS and IPFS Cluster are running and reports their versions
+3. Migrates the live IPFS config for the target Kubo version
+4. Updates managed image tags in `docker-compose.yml` and removes the legacy config bind mount (unless `--skip-compose-update` is specified, which leaves the compose file untouched and migrates the config against the current repo version instead)
+5. Pulls the requested Docker images and reports image changes
+6. Restarts or starts services with the new images
+7. Verifies IPFS and IPFS Cluster are running and reports their versions
 
 ### IPFS Peering
 

--- a/packages/bgipfs/README.md
+++ b/packages/bgipfs/README.md
@@ -78,9 +78,16 @@ bgipfs cluster config --mode ipfs --ipfs-dry-run
 #### Configuration Files
 - `identity.json` - Cluster peer identity [DO NOT SHARE]
 - `service.json` - Cluster service configuration
-- `ipfs.config.json` - IPFS node configuration
+- `data/ipfs/config` - live Kubo configuration used by new and updated clusters
+- `ipfs.config.json` - legacy IPFS node configuration only for older compose files that still bind-mount it
 - `auth/admin-htpasswd` - Admin credentials for dashboard access
 - `auth/user-htpasswd` - User credentials for upload endpoint
+
+For new and updated clusters, Kubo owns its live repository config at `data/ipfs/config`. Use
+`bgipfs cluster config --mode ipfs` to apply bgipfs-managed IPFS config changes, or edit
+`data/ipfs/config` directly for manual Kubo settings before restarting the cluster.
+New clusters do not create `ipfs.config.json`. During legacy upgrades, any old exported
+`ipfs.config.json` is archived after the bind mount is removed and the upgraded cluster verifies.
 
 #### Backup
 The `cluster backup` command creates a complete backup of your IPFS cluster, including:
@@ -100,7 +107,7 @@ bgipfs cluster backup --output ./my-backup
 
 ### Updating
 
-The `cluster update` command helps you update IPFS and IPFS Cluster to their latest versions:
+The `cluster update` command helps you update Kubo, IPFS Cluster, and Traefik Docker images:
 
 ```bash
 # Update with automatic backup
@@ -111,14 +118,21 @@ bgipfs cluster update --no-backup
 
 # Update with backup to specific directory
 bgipfs cluster update --backup-dir ./my-backup
+
+# Include data/ipfs and data/ipfs-cluster in the filesystem backup
+bgipfs cluster update --backup-data
+
+# Pin specific Docker tags instead of the defaults
+bgipfs cluster update --ipfs-version v0.41.0 --cluster-version v1.1.6 --traefik-version v3.6.1
 ```
 
 The update process:
-1. Creates a backup of all data and configuration (unless --no-backup is specified)
-2. Stops the running services
-3. Pulls the latest Docker images
-4. Starts the services with the new versions
-5. Verifies all services are running correctly
+1. Checks Docker Compose and the local compose file
+2. Creates a backup of configuration files (unless --no-backup is specified). Use `--backup-data` or a volume snapshot for IPFS data.
+3. Updates managed image tags in `docker-compose.yml` (unless `--skip-compose-update` is specified)
+4. Pulls the requested Docker images and reports image changes
+5. Restarts or starts services with the new images
+6. Verifies IPFS and IPFS Cluster are running and reports their versions
 
 ### IPFS Peering
 

--- a/packages/bgipfs/src/commands/cluster/config/index.ts
+++ b/packages/bgipfs/src/commands/cluster/config/index.ts
@@ -8,12 +8,14 @@ import {z} from 'zod'
 import {BaseCommand} from '../../../base-command.js'
 import {AuthService} from '../../../lib/auth-service.js'
 import {getBgipfsIpfsConfigPolicy} from '../../../lib/bgipfs-owned-keys.js'
+import {usesIpfsConfigBindMount} from '../../../lib/compose-file.js'
 import {EnvManager} from '../../../lib/env-manager.js'
 import {baseSchema} from '../../../lib/env-schema.js'
 import {
   type IpfsConfigChange,
   backupIpfsConfig,
   computeIpfsConfigChanges,
+  getLiveIpfsConfigPath,
   mergeIpfsConfig,
   readIpfsConfig,
   readIpfsRepoVersion,
@@ -119,7 +121,7 @@ export default class Init extends BaseCommand {
         this.logInfo('Your cluster identity is in identity.json')
         this.logInfo('Your cluster service configuration is in service.json')
         this.logInfo('Your live IPFS daemon configuration is in data/ipfs/config')
-        if (await this.usesIpfsConfigBindMount()) {
+        if (await usesIpfsConfigBindMount()) {
           this.logInfo('Your legacy bind-mounted IPFS daemon configuration is in ipfs.config.json')
         }
 
@@ -217,7 +219,7 @@ export default class Init extends BaseCommand {
   private async configureIpfsConfig(force: boolean, dryRun: boolean): Promise<void> {
     this.logInfo('Checking IPFS daemon configuration...')
 
-    const liveConfigPath = await this.getLiveIpfsConfigPath()
+    const liveConfigPath = await getLiveIpfsConfigPath()
     const config = await readIpfsConfig(liveConfigPath)
     const repoVersion = await readIpfsRepoVersion()
     const policy = getBgipfsIpfsConfigPolicy(config, repoVersion)
@@ -330,23 +332,6 @@ export default class Init extends BaseCommand {
     return randomBytes(32).toString('hex')
   }
 
-  private async getLiveIpfsConfigPath(): Promise<string> {
-    const repoConfigPath = 'data/ipfs/config'
-    const hasRepoConfig = await fs
-      .access(repoConfigPath)
-      .then(() => true)
-      .catch(() => false)
-
-    if (!hasRepoConfig) {
-      return 'ipfs.config.json'
-    }
-
-    const compose = await fs.readFile('docker-compose.yml', 'utf8').catch(() => '')
-    const usesBindMount = compose.split('\n').some((line) => line.trim() === '- ./ipfs.config.json:/data/ipfs/config:ro')
-
-    return usesBindMount ? 'ipfs.config.json' : repoConfigPath
-  }
-
   private async getPeerAddresses(flags: {force: boolean}, currentEnv: {PEERADDRESSES: string}): Promise<string> {
     return flags.force
       ? currentEnv.PEERADDRESSES
@@ -449,7 +434,7 @@ export default class Init extends BaseCommand {
       )
       if (!serviceSuccess) return
 
-      if (await this.usesIpfsConfigBindMount()) {
+      if (await usesIpfsConfigBindMount()) {
         // Older compose files bind-mount this exported config into the Kubo repo.
         const ipfsSuccess = await this.copyWithConfirmation(
           'data/ipfs/config',
@@ -517,11 +502,6 @@ export default class Init extends BaseCommand {
         }
       })
       .catch(() => defaultEnv)
-  }
-
-  private async usesIpfsConfigBindMount(): Promise<boolean> {
-    const compose = await fs.readFile('docker-compose.yml', 'utf8').catch(() => '')
-    return compose.split('\n').some((line) => line.trim() === '- ./ipfs.config.json:/data/ipfs/config:ro')
   }
 
   private validateInput(schema: z.ZodType, value: string): string | true {

--- a/packages/bgipfs/src/commands/cluster/config/index.ts
+++ b/packages/bgipfs/src/commands/cluster/config/index.ts
@@ -118,7 +118,11 @@ export default class Init extends BaseCommand {
       if (shouldRunInitialization) {
         this.logInfo('Your cluster identity is in identity.json')
         this.logInfo('Your cluster service configuration is in service.json')
-        this.logInfo('Your IPFS daemon configuration is in ipfs.config.json')
+        this.logInfo('Your live IPFS daemon configuration is in data/ipfs/config')
+        if (await this.usesIpfsConfigBindMount()) {
+          this.logInfo('Your legacy bind-mounted IPFS daemon configuration is in ipfs.config.json')
+        }
+
         this.logInfo('You can now start the cluster with `bgipfs cluster start`')
       } else if (shouldRunIpfs) {
         this.logInfo('Restart the cluster with `bgipfs cluster restart` for IPFS config changes to take effect')
@@ -213,13 +217,14 @@ export default class Init extends BaseCommand {
   private async configureIpfsConfig(force: boolean, dryRun: boolean): Promise<void> {
     this.logInfo('Checking IPFS daemon configuration...')
 
-    const config = await readIpfsConfig()
+    const liveConfigPath = await this.getLiveIpfsConfigPath()
+    const config = await readIpfsConfig(liveConfigPath)
     const repoVersion = await readIpfsRepoVersion()
     const policy = getBgipfsIpfsConfigPolicy(config, repoVersion)
     const changes = computeIpfsConfigChanges(config, policy.ownedKeys, policy.removedKeys)
 
     if (changes.length === 0) {
-      this.logSuccess('ipfs.config.json is already current')
+      this.logSuccess(`${liveConfigPath} is already current`)
       return
     }
 
@@ -239,11 +244,11 @@ export default class Init extends BaseCommand {
       }
     }
 
-    const backupPath = await backupIpfsConfig()
+    const backupPath = await backupIpfsConfig(liveConfigPath)
     const merged = mergeIpfsConfig(config, policy.ownedKeys, policy.removedKeys)
-    await writeIpfsConfig(merged)
+    await writeIpfsConfig(merged, liveConfigPath)
 
-    this.logSuccess(`Backed up ipfs.config.json to ${backupPath}`)
+    this.logSuccess(`Backed up ${liveConfigPath} to ${backupPath}`)
     this.logSuccess('IPFS config updated')
   }
 
@@ -323,6 +328,23 @@ export default class Init extends BaseCommand {
 
   private generateSecret(): string {
     return randomBytes(32).toString('hex')
+  }
+
+  private async getLiveIpfsConfigPath(): Promise<string> {
+    const repoConfigPath = 'data/ipfs/config'
+    const hasRepoConfig = await fs
+      .access(repoConfigPath)
+      .then(() => true)
+      .catch(() => false)
+
+    if (!hasRepoConfig) {
+      return 'ipfs.config.json'
+    }
+
+    const compose = await fs.readFile('docker-compose.yml', 'utf8').catch(() => '')
+    const usesBindMount = compose.split('\n').some((line) => line.trim() === '- ./ipfs.config.json:/data/ipfs/config:ro')
+
+    return usesBindMount ? 'ipfs.config.json' : repoConfigPath
   }
 
   private async getPeerAddresses(flags: {force: boolean}, currentEnv: {PEERADDRESSES: string}): Promise<string> {
@@ -427,14 +449,18 @@ export default class Init extends BaseCommand {
       )
       if (!serviceSuccess) return
 
-      // Handle ipfs.config.json
-      const ipfsSuccess = await this.copyWithConfirmation(
-        'data/ipfs/config',
-        'ipfs.config.json',
-        force,
-        'ipfs.config.json',
-      )
-      if (!ipfsSuccess) return
+      if (await this.usesIpfsConfigBindMount()) {
+        // Older compose files bind-mount this exported config into the Kubo repo.
+        const ipfsSuccess = await this.copyWithConfirmation(
+          'data/ipfs/config',
+          'ipfs.config.json',
+          force,
+          'ipfs.config.json',
+        )
+        if (!ipfsSuccess) return
+      } else {
+        this.logSuccess('Live IPFS config is available at data/ipfs/config')
+      }
 
       this.logSuccess('Configuration files copied successfully')
     } catch (error) {
@@ -491,6 +517,11 @@ export default class Init extends BaseCommand {
         }
       })
       .catch(() => defaultEnv)
+  }
+
+  private async usesIpfsConfigBindMount(): Promise<boolean> {
+    const compose = await fs.readFile('docker-compose.yml', 'utf8').catch(() => '')
+    return compose.split('\n').some((line) => line.trim() === '- ./ipfs.config.json:/data/ipfs/config:ro')
   }
 
   private validateInput(schema: z.ZodType, value: string): string | true {

--- a/packages/bgipfs/src/commands/cluster/reset/index.ts
+++ b/packages/bgipfs/src/commands/cluster/reset/index.ts
@@ -53,7 +53,7 @@ export default class Reset extends BaseCommand {
       if (flags.config) {
         // Remove config files
         this.logInfo('Removing configuration files...')
-        const configFiles = ['.env', 'htpasswd', 'identity.json', 'service.json']
+        const configFiles = ['.env', 'htpasswd', 'identity.json', 'ipfs.config.json', 'service.json']
 
         await Promise.all(
           configFiles.map((file: string) =>

--- a/packages/bgipfs/src/commands/cluster/reset/index.ts
+++ b/packages/bgipfs/src/commands/cluster/reset/index.ts
@@ -46,12 +46,9 @@ export default class Reset extends BaseCommand {
       this.logInfo('Stopping and removing containers...')
       await execa('docker', ['compose', 'down', '--remove-orphans', '-v'])
 
-      // Remove data directory
-      this.logInfo('Removing data directory...')
-      await fs.rm('data', {force: true, recursive: true})
-
       if (flags.config) {
-        // Remove config files
+        // Remove config files before the data directory, which can fail on
+        // container-owned files; the config cleanup should still complete.
         this.logInfo('Removing configuration files...')
         const configFiles = ['.env', 'htpasswd', 'identity.json', 'ipfs.config.json', 'service.json']
 
@@ -64,6 +61,10 @@ export default class Reset extends BaseCommand {
         )
       }
 
+      // Remove data directory
+      this.logInfo('Removing data directory...')
+      await this.removeDataDirectory()
+
       this.logSuccess('Reset complete')
       if (flags.config) {
         this.logInfo("You can now run 'bgipfs cluster config' to reconfigure the cluster")
@@ -72,6 +73,22 @@ export default class Reset extends BaseCommand {
       }
     } catch (error) {
       this.logError(`Reset failed: ${(error as Error).message}`)
+    }
+  }
+
+  private async removeDataDirectory(): Promise<void> {
+    try {
+      await fs.rm('data', {force: true, recursive: true})
+    } catch (error) {
+      const {code} = error as NodeJS.ErrnoException
+      if (code !== 'EACCES' && code !== 'EPERM') {
+        throw error
+      }
+
+      throw new Error(
+        'Cannot remove the data directory as the current host user (its contents are owned by the container user). ' +
+          'Remove it manually:\nsudo rm -rf data',
+      )
     }
   }
 }

--- a/packages/bgipfs/src/commands/cluster/start/index.ts
+++ b/packages/bgipfs/src/commands/cluster/start/index.ts
@@ -5,6 +5,7 @@ import {promises as fs} from 'node:fs'
 import {BaseCommand} from '../../../base-command.js'
 import {EnvManager} from '../../../lib/env-manager.js'
 import {DnsConfig, dnsSchema} from '../../../lib/env-schema.js'
+import {getLiveIpfsConfigPath, writeIpfsConfig} from '../../../lib/ipfs-config.js'
 import {checkRunningContainers} from '../../../lib/system.js'
 
 export default class Start extends BaseCommand {
@@ -34,7 +35,7 @@ export default class Start extends BaseCommand {
         composeFiles.push('docker-compose.dns.yml')
       }
 
-      const ipfsConfigPath = await this.getLiveIpfsConfigPath()
+      const ipfsConfigPath = await getLiveIpfsConfigPath()
       this.logInfo(`Using compose files: ${composeFiles.join(', ')}`)
 
       // Check required files
@@ -182,23 +183,6 @@ export default class Start extends BaseCommand {
     }
   }
 
-  private async getLiveIpfsConfigPath(): Promise<string> {
-    const repoConfigPath = 'data/ipfs/config'
-    const hasRepoConfig = await fs
-      .access(repoConfigPath)
-      .then(() => true)
-      .catch(() => false)
-
-    if (!hasRepoConfig) {
-      return 'ipfs.config.json'
-    }
-
-    const compose = await fs.readFile('docker-compose.yml', 'utf8').catch(() => '')
-    const usesBindMount = compose.split('\n').some((line) => line.trim() === '- ./ipfs.config.json:/data/ipfs/config:ro')
-
-    return usesBindMount ? 'ipfs.config.json' : repoConfigPath
-  }
-
   private async updateIpfsConfig(configPath: string, gatewayDomain: string): Promise<void> {
     const config = JSON.parse(await fs.readFile(configPath, 'utf8'))
     const publicGateways = config.Gateway.PublicGateways || {}
@@ -225,7 +209,7 @@ export default class Start extends BaseCommand {
         },
       }
 
-      await fs.writeFile(configPath, JSON.stringify(config, null, 2))
+      await writeIpfsConfig(config, configPath)
       this.logSuccess('IPFS config updated')
     }
   }

--- a/packages/bgipfs/src/commands/cluster/start/index.ts
+++ b/packages/bgipfs/src/commands/cluster/start/index.ts
@@ -27,17 +27,6 @@ export default class Start extends BaseCommand {
     try {
       this.logInfo(`Starting IPFS cluster in ${flags.mode.toUpperCase()} mode...`)
 
-      // Update IPFS config in DNS mode
-      if (flags.mode === 'dns') {
-        try {
-          const env = (await new EnvManager().readEnv({schema: dnsSchema})) as DnsConfig
-          await this.updateIpfsConfig(env.GATEWAY_DOMAIN)
-        } catch (error) {
-          this.logError(`Failed to process IPFS config: ${(error as Error).message}`)
-          return
-        }
-      }
-
       // Build compose file list
       const composeFiles = ['docker-compose.yml']
       if (flags.mode === 'dns') {
@@ -45,6 +34,7 @@ export default class Start extends BaseCommand {
         composeFiles.push('docker-compose.dns.yml')
       }
 
+      const ipfsConfigPath = await this.getLiveIpfsConfigPath()
       this.logInfo(`Using compose files: ${composeFiles.join(', ')}`)
 
       // Check required files
@@ -55,7 +45,7 @@ export default class Start extends BaseCommand {
         'identity.json',
         'auth/admin-htpasswd',
         'auth/user-htpasswd',
-        'ipfs.config.json',
+        ipfsConfigPath,
       ]
 
       // Check all required files
@@ -67,6 +57,17 @@ export default class Start extends BaseCommand {
           this.logSuccess(`Found ${file}`)
         } catch {
           this.logError(`Missing required file: ${file}`)
+          return
+        }
+      }
+
+      // Update IPFS config in DNS mode
+      if (flags.mode === 'dns') {
+        try {
+          const env = (await new EnvManager().readEnv({schema: dnsSchema})) as DnsConfig
+          await this.updateIpfsConfig(ipfsConfigPath, env.GATEWAY_DOMAIN)
+        } catch (error) {
+          this.logError(`Failed to process IPFS config: ${(error as Error).message}`)
           return
         }
       }
@@ -181,8 +182,24 @@ export default class Start extends BaseCommand {
     }
   }
 
-  private async updateIpfsConfig(gatewayDomain: string): Promise<void> {
-    const configPath = 'ipfs.config.json'
+  private async getLiveIpfsConfigPath(): Promise<string> {
+    const repoConfigPath = 'data/ipfs/config'
+    const hasRepoConfig = await fs
+      .access(repoConfigPath)
+      .then(() => true)
+      .catch(() => false)
+
+    if (!hasRepoConfig) {
+      return 'ipfs.config.json'
+    }
+
+    const compose = await fs.readFile('docker-compose.yml', 'utf8').catch(() => '')
+    const usesBindMount = compose.split('\n').some((line) => line.trim() === '- ./ipfs.config.json:/data/ipfs/config:ro')
+
+    return usesBindMount ? 'ipfs.config.json' : repoConfigPath
+  }
+
+  private async updateIpfsConfig(configPath: string, gatewayDomain: string): Promise<void> {
     const config = JSON.parse(await fs.readFile(configPath, 'utf8'))
     const publicGateways = config.Gateway.PublicGateways || {}
 

--- a/packages/bgipfs/src/commands/cluster/update/index.ts
+++ b/packages/bgipfs/src/commands/cluster/update/index.ts
@@ -2,13 +2,44 @@ import {Flags} from '@oclif/core'
 import {execa} from 'execa'
 import {promises as fs} from 'node:fs'
 import path from 'node:path'
+import {setTimeout as delay} from 'node:timers/promises'
 
 import {BaseCommand} from '../../../base-command.js'
 import {getBgipfsIpfsConfigPolicy} from '../../../lib/bgipfs-owned-keys.js'
-import {backupIpfsConfig, mergeIpfsConfig, readIpfsConfig, readIpfsRepoVersion, writeIpfsConfig} from '../../../lib/ipfs-config.js'
+import {
+  isValidDockerTag,
+  removeIpfsConfigBindMount,
+  replaceServiceImage,
+  usesIpfsConfigBindMount,
+} from '../../../lib/compose-file.js'
+import {
+  LEGACY_IPFS_CONFIG_PATH,
+  REPO_IPFS_CONFIG_PATH,
+  backupIpfsConfig,
+  getLiveIpfsConfigPath,
+  getTargetRepoVersion,
+  ipfsConfigWritePermissionHint,
+  mergeIpfsConfig,
+  readIpfsConfig,
+  readIpfsRepoVersion,
+  writeIpfsConfig,
+} from '../../../lib/ipfs-config.js'
 import {checkRunningContainers, getContainerVersions} from '../../../lib/system.js'
 import Restart from '../restart/index.js'
 import Start from '../start/index.js'
+
+const VERSION_FLAGS = ['cluster-version', 'ipfs-version', 'traefik-version'] as const
+
+interface UpdateFlags {
+  'backup-data': boolean
+  'backup-dir': string | undefined
+  'cluster-version': string
+  force: boolean
+  'ipfs-version': string
+  'no-backup': boolean
+  'skip-compose-update': boolean
+  'traefik-version': string
+}
 
 export default class Update extends BaseCommand {
   static description = 'Update IPFS, IPFS Cluster, and key cluster dependencies'
@@ -47,7 +78,8 @@ export default class Update extends BaseCommand {
     }),
     'skip-compose-update': Flags.boolean({
       default: false,
-      description: 'Do not update managed Docker image tags in docker-compose.yml',
+      description:
+        'Leave docker-compose.yml untouched (skips image tag updates and legacy config bind mount removal; the IPFS config migration still runs against the current repo version)',
     }),
     'traefik-version': Flags.string({
       default: 'v3.6.1',
@@ -55,22 +87,20 @@ export default class Update extends BaseCommand {
     }),
   }
 
-  // eslint-disable-next-line complexity
   async run(): Promise<void> {
     const {flags} = await this.parse(Update)
 
     try {
-      await this.preflight()
+      await this.preflight(flags)
 
       // Check if services are running
       const running = await checkRunningContainers()
       const isRunning = running.length > 0
 
       // Get current versions if services are running
-      let currentVersions: {cluster: string; ipfs: string} | undefined
       if (isRunning) {
         try {
-          currentVersions = await getContainerVersions()
+          const currentVersions = await getContainerVersions()
           this.logInfo(`Current versions:
   IPFS: ${currentVersions.ipfs}
   IPFS Cluster: ${currentVersions.cluster}`)
@@ -90,42 +120,9 @@ export default class Update extends BaseCommand {
         }
       }
 
-      // Handle backup
-      if (!flags['no-backup']) {
-        const backupDir =
-          flags['backup-dir'] || `backup_${new Date().toISOString().replaceAll(/[.:]/g, '').slice(0, 15)}`
+      await this.maybeCreateBackup(flags)
 
-        if (flags.force) {
-          await this.createBackup(backupDir, flags['backup-data'])
-        } else {
-          const shouldBackup = await this.confirm(
-            `Would you like to create a backup before updating? (Will be stored in ${backupDir})`,
-          )
-          if (shouldBackup) {
-            await this.createBackup(backupDir, flags['backup-data'])
-          } else {
-            this.logInfo('Skipping backup')
-          }
-        }
-      }
-
-      const usesConfigBindMount = !flags['skip-compose-update'] && (await this.usesIpfsConfigBindMount())
-      if (!flags['skip-compose-update']) {
-        const ipfsConfigPath = usesConfigBindMount ? 'ipfs.config.json' : await this.getLiveIpfsConfigPath()
-        await this.migrateIpfsConfig(flags['ipfs-version'], ipfsConfigPath)
-      }
-
-      if (usesConfigBindMount) {
-        await this.stageIpfsConfigForUnmountedRepo()
-      }
-
-      const composeChanged = flags['skip-compose-update']
-        ? false
-        : await this.updateManagedImageTags({
-          clusterVersion: flags['cluster-version'],
-          ipfsVersion: flags['ipfs-version'],
-          traefikVersion: flags['traefik-version'],
-        })
+      const {composeChanged, willRemoveBindMount} = await this.prepareConfigAndCompose(flags)
 
       const beforeImages = await this.getComposeImageIds()
       const beforeRunningImages = isRunning ? await this.getRunningServiceImageIds() : new Map<string, string>()
@@ -137,13 +134,14 @@ export default class Update extends BaseCommand {
       const afterImages = await this.getComposeImageIds()
       const afterServiceImages = await this.getComposeServiceImageIds()
       this.logImageChanges(beforeImages, afterImages)
+
+      const imagesChanged = [...afterImages].some(
+        ([image, imageId]) => beforeImages.get(image) !== undefined && beforeImages.get(image) !== imageId,
+      )
       const runningImagesOutdated = isRunning && this.hasRunningImageMismatch(beforeRunningImages, afterServiceImages)
 
-      // Check if versions changed
-      if (
-        isRunning &&
-        !(await this.checkVersions(currentVersions, beforeImages, afterImages, composeChanged || runningImagesOutdated))
-      ) {
+      if (isRunning && !composeChanged && !imagesChanged && !runningImagesOutdated) {
+        this.logInfo('No updates available - all images are up to date')
         return
       }
 
@@ -156,9 +154,9 @@ export default class Update extends BaseCommand {
         await Start.run([])
       }
 
-      this.logSuccess('IPFS cluster updated successfully')
       await this.verifyUpdatedCluster()
-      if (usesConfigBindMount) {
+      this.logSuccess('IPFS cluster updated successfully')
+      if (willRemoveBindMount) {
         await this.archiveLegacyIpfsConfig()
       }
 
@@ -174,9 +172,8 @@ export default class Update extends BaseCommand {
   }
 
   private async archiveLegacyIpfsConfig(): Promise<void> {
-    const legacyPath = 'ipfs.config.json'
     const hasLegacyConfig = await fs
-      .access(legacyPath)
+      .access(LEGACY_IPFS_CONFIG_PATH)
       .then(() => true)
       .catch(() => false)
 
@@ -184,50 +181,10 @@ export default class Update extends BaseCommand {
       return
     }
 
-    const archivePath = `${legacyPath}.legacy-${new Date().toISOString().replaceAll(/[.:]/g, '-')}`
-    await fs.rename(legacyPath, archivePath)
+    const archivePath = `${LEGACY_IPFS_CONFIG_PATH}.legacy-${new Date().toISOString().replaceAll(/[.:]/g, '-')}`
+    await fs.rename(LEGACY_IPFS_CONFIG_PATH, archivePath)
     this.logInfo(`Archived legacy exported IPFS config to ${archivePath}`)
-    this.logInfo('The live Kubo config is now data/ipfs/config')
-  }
-
-  private async checkVersions(
-    currentVersions?: {cluster: string; ipfs: string},
-    beforeImages?: Map<string, string>,
-    afterImages?: Map<string, string>,
-    restartNeeded = false,
-  ): Promise<boolean> {
-    const imagesChanged =
-      beforeImages &&
-      afterImages &&
-      [...afterImages].some(([image, imageId]) => beforeImages.get(image) && beforeImages.get(image) !== imageId)
-
-    try {
-      const newVersions = await getContainerVersions()
-      if (currentVersions) {
-        const ipfsUpdated = newVersions.ipfs !== currentVersions.ipfs
-        const clusterUpdated = newVersions.cluster !== currentVersions.cluster
-
-        if (!ipfsUpdated && !clusterUpdated) {
-          if (!imagesChanged && !restartNeeded) {
-            this.logInfo('No updates available - already running latest versions')
-            return false
-          }
-
-          this.logInfo('Restarting to apply updated image configuration')
-        }
-
-        if (ipfsUpdated || clusterUpdated) {
-          this.logInfo(`New versions available:
-  IPFS: ${currentVersions.ipfs} -> ${newVersions.ipfs}
-  IPFS Cluster: ${currentVersions.cluster} -> ${newVersions.cluster}`)
-        }
-      }
-
-      return true
-    } catch (error) {
-      this.logWarning(`Failed to check new versions: ${(error as Error).message}`)
-      return true // Continue with update if version check fails
-    }
+    this.logInfo(`The live Kubo config is now ${REPO_IPFS_CONFIG_PATH}`)
   }
 
   private async createBackup(backupDir: string, includeData: boolean): Promise<void> {
@@ -245,8 +202,8 @@ export default class Update extends BaseCommand {
 
     // Large blockstores should be backed up with volume snapshots in production.
     const itemsToBackup = [
-      {dest: 'ipfs.config.json', optional: true, src: 'ipfs.config.json'},
-      {dest: 'data/ipfs/config', optional: true, src: 'data/ipfs/config'},
+      {dest: 'ipfs.config.json', optional: true, src: LEGACY_IPFS_CONFIG_PATH},
+      {dest: 'data/ipfs/config', optional: true, src: REPO_IPFS_CONFIG_PATH},
       {dest: 'service.json', src: 'service.json'},
       {dest: 'identity.json', src: 'identity.json'},
       {dest: 'auth', src: 'auth'},
@@ -305,17 +262,23 @@ export default class Update extends BaseCommand {
 
   private async getComposeServiceImageIds(): Promise<Map<string, string>> {
     const {stdout} = await execa('docker', ['compose', 'config', '--format', 'json'])
-    const config = JSON.parse(stdout) as {services: Record<string, {image?: string}>}
+    const composeConfig = JSON.parse(stdout) as {services: Record<string, {image?: string}>}
     const serviceImages = new Map<string, string>()
 
     await Promise.all(
-      Object.entries(config.services).map(async ([service, config]) => {
-        if (!config.image) {
+      Object.entries(composeConfig.services).map(async ([service, serviceConfig]) => {
+        if (!serviceConfig.image) {
           return
         }
 
         try {
-          const {stdout: imageId} = await execa('docker', ['image', 'inspect', config.image, '--format', '{{.Id}}'])
+          const {stdout: imageId} = await execa('docker', [
+            'image',
+            'inspect',
+            serviceConfig.image,
+            '--format',
+            '{{.Id}}',
+          ])
           serviceImages.set(service, imageId.trim())
         } catch {
           serviceImages.set(service, 'not-present')
@@ -324,16 +287,6 @@ export default class Update extends BaseCommand {
     )
 
     return serviceImages
-  }
-
-  private async getLiveIpfsConfigPath(): Promise<string> {
-    const repoConfigPath = 'data/ipfs/config'
-    const hasRepoConfig = await fs
-      .access(repoConfigPath)
-      .then(() => true)
-      .catch(() => false)
-
-    return hasRepoConfig ? repoConfigPath : 'ipfs.config.json'
   }
 
   private async getRunningServiceImageIds(): Promise<Map<string, string>> {
@@ -353,16 +306,6 @@ export default class Update extends BaseCommand {
     )
 
     return serviceImages
-  }
-
-  private getTargetRepoVersion(ipfsVersion: string): number | undefined {
-    const match = ipfsVersion.match(/^v?(\d+)\.(\d+)\.(\d+)/)
-    if (!match) {
-      return undefined
-    }
-
-    const [, major, minor] = match.map(Number)
-    return major > 0 || minor >= 38 ? 18 : undefined
   }
 
   private hasRunningImageMismatch(
@@ -387,7 +330,9 @@ export default class Update extends BaseCommand {
       const beforeId = beforeImages.get(image)
       if (!beforeId) {
         this.logInfo(`${image}: newly tracked`)
-      } else if (beforeId === 'not-present' && afterId !== 'not-present') {
+      } else if (afterId === 'not-present') {
+        this.logWarning(`${image}: not present locally after pull`)
+      } else if (beforeId === 'not-present') {
         this.logSuccess(`${image}: pulled`)
       } else if (beforeId === afterId) {
         this.logInfo(`${image}: unchanged`)
@@ -397,9 +342,42 @@ export default class Update extends BaseCommand {
     }
   }
 
-  private async migrateIpfsConfig(ipfsVersion: string, configPath: string): Promise<void> {
+  private async maybeCreateBackup(flags: UpdateFlags): Promise<void> {
+    if (flags['no-backup']) {
+      return
+    }
+
+    const backupDir = flags['backup-dir'] || `backup_${new Date().toISOString().replaceAll(/[.:]/g, '').slice(0, 15)}`
+
+    if (flags.force) {
+      await this.createBackup(backupDir, flags['backup-data'])
+      return
+    }
+
+    const shouldBackup = await this.confirm(
+      `Would you like to create a backup before updating? (Will be stored in ${backupDir})`,
+    )
+    if (shouldBackup) {
+      await this.createBackup(backupDir, flags['backup-data'])
+    } else {
+      this.logInfo('Skipping backup')
+    }
+  }
+
+  private async migrateIpfsConfig(targetIpfsVersion: string | undefined, configPath: string): Promise<void> {
+    const hasConfig = await fs
+      .access(configPath)
+      .then(() => true)
+      .catch(() => false)
+
+    if (!hasConfig) {
+      this.logWarning(`No IPFS config found at ${configPath}; skipping config migration`)
+      return
+    }
+
     const config = await readIpfsConfig(configPath)
-    const repoVersion = this.getTargetRepoVersion(ipfsVersion) ?? (await readIpfsRepoVersion())
+    const targetRepoVersion = targetIpfsVersion === undefined ? undefined : getTargetRepoVersion(targetIpfsVersion)
+    const repoVersion = targetRepoVersion ?? (await readIpfsRepoVersion())
     const policy = getBgipfsIpfsConfigPolicy(config, repoVersion)
     const migrated = mergeIpfsConfig(config, policy.ownedKeys, policy.removedKeys)
 
@@ -413,55 +391,61 @@ export default class Update extends BaseCommand {
     this.logSuccess(`Migrated IPFS config for target Kubo version; backup saved to ${backupPath}`)
   }
 
-  private async preflight(): Promise<void> {
+  private async preflight(flags: UpdateFlags): Promise<void> {
+    for (const flag of VERSION_FLAGS) {
+      if (!isValidDockerTag(flags[flag])) {
+        throw new Error(`Invalid Docker image tag for --${flag}: "${flags[flag]}"`)
+      }
+    }
+
     await execa('docker', ['compose', 'version'])
     await fs.access('docker-compose.yml')
   }
 
-  private removeIpfsConfigBindMount(compose: string): string {
-    return compose
-      .split('\n')
-      .filter((line) => line.trim() !== '- ./ipfs.config.json:/data/ipfs/config:ro')
-      .join('\n')
-  }
+  private async prepareConfigAndCompose(
+    flags: UpdateFlags,
+  ): Promise<{composeChanged: boolean; willRemoveBindMount: boolean}> {
+    const skipComposeUpdate = flags['skip-compose-update']
+    const usesBindMount = await usesIpfsConfigBindMount()
+    const willRemoveBindMount = usesBindMount && !skipComposeUpdate
 
-  private replaceServiceImage(compose: string, service: string, image: string): string {
-    const lines = compose.split('\n')
-    const servicePattern = new RegExp(`^  ${service}:\\s*$`)
-
-    const serviceStart = lines.findIndex((line) => servicePattern.test(line))
-    if (serviceStart === -1) {
-      throw new Error(`Could not find ${service} service in docker-compose.yml`)
+    if (usesBindMount && skipComposeUpdate) {
+      this.logWarning(
+        'Legacy read-only IPFS config bind mount detected, but --skip-compose-update leaves it in place. ' +
+          'Kubo upgrades cannot migrate the repo until it is removed; re-run without --skip-compose-update.',
+      )
     }
 
-    for (let index = serviceStart + 1; index < lines.length; index++) {
-      if (/^ {2}[\w-]+:\s*$/.test(lines[index])) {
-        break
-      }
+    // The config migration always runs against the live config; it only
+    // targets the pinned Kubo version when the compose tags are updated to it.
+    await this.migrateIpfsConfig(skipComposeUpdate ? undefined : flags['ipfs-version'], await getLiveIpfsConfigPath())
 
-      if (/^ {4}image:\s*/.test(lines[index])) {
-        lines[index] = `    image: ${image}`
-        return lines.join('\n')
-      }
+    if (willRemoveBindMount) {
+      await this.stageIpfsConfigForUnmountedRepo()
     }
 
-    throw new Error(`Could not find image for ${service} service in docker-compose.yml`)
+    const composeChanged = skipComposeUpdate
+      ? false
+      : await this.updateManagedImageTags({
+          clusterVersion: flags['cluster-version'],
+          ipfsVersion: flags['ipfs-version'],
+          traefikVersion: flags['traefik-version'],
+        })
+
+    return {composeChanged, willRemoveBindMount}
   }
 
   private async stageIpfsConfigForUnmountedRepo(): Promise<void> {
     try {
-      await fs.copyFile('ipfs.config.json', 'data/ipfs/config')
-      this.logSuccess('Staged ipfs.config.json into data/ipfs/config')
+      await fs.copyFile(LEGACY_IPFS_CONFIG_PATH, REPO_IPFS_CONFIG_PATH)
+      this.logSuccess(`Staged ${LEGACY_IPFS_CONFIG_PATH} into ${REPO_IPFS_CONFIG_PATH}`)
     } catch (error) {
-      const nodeError = error as NodeJS.ErrnoException
-      if (nodeError.code !== 'EACCES' && nodeError.code !== 'EPERM') {
+      const {code} = error as NodeJS.ErrnoException
+      if (code !== 'EACCES' && code !== 'EPERM') {
         throw error
       }
 
-      throw new Error(
-        'Cannot write data/ipfs/config with the current host user. Run this command, then retry the update:\n' +
-          'sudo install -m 0644 -o "$(stat -c %u data/ipfs)" -g "$(stat -c %g data/ipfs)" ipfs.config.json data/ipfs/config',
-      )
+      throw new Error(ipfsConfigWritePermissionHint(REPO_IPFS_CONFIG_PATH))
     }
   }
 
@@ -474,10 +458,10 @@ export default class Update extends BaseCommand {
     const original = await fs.readFile(composePath, 'utf8')
     let updated = original
 
-    updated = this.replaceServiceImage(updated, 'ipfs', `ipfs/kubo:${versions.ipfsVersion}`)
-    updated = this.replaceServiceImage(updated, 'cluster', `ipfs/ipfs-cluster:${versions.clusterVersion}`)
-    updated = this.replaceServiceImage(updated, 'traefik', `traefik:${versions.traefikVersion}`)
-    updated = this.removeIpfsConfigBindMount(updated)
+    updated = replaceServiceImage(updated, 'ipfs', `ipfs/kubo:${versions.ipfsVersion}`)
+    updated = replaceServiceImage(updated, 'cluster', `ipfs/ipfs-cluster:${versions.clusterVersion}`)
+    updated = replaceServiceImage(updated, 'traefik', `traefik:${versions.traefikVersion}`)
+    updated = removeIpfsConfigBindMount(updated)
 
     if (updated === original) {
       this.logInfo('Docker image tags are already up to date')
@@ -492,20 +476,38 @@ export default class Update extends BaseCommand {
     return true
   }
 
-  private async usesIpfsConfigBindMount(): Promise<boolean> {
-    const compose = await fs.readFile('docker-compose.yml', 'utf8')
-    return compose.split('\n').some((line) => line.trim() === '- ./ipfs.config.json:/data/ipfs/config:ro')
-  }
-
   private async verifyUpdatedCluster(): Promise<void> {
-    const running = await checkRunningContainers()
-    for (const service of ['ipfs', 'cluster']) {
-      if (!running.some((container) => container.includes(service))) {
-        throw new Error(`${service} container is not running after update`)
+    this.logInfo('Verifying services after update...')
+    const requiredServices = ['ipfs', 'cluster']
+    let consecutiveHealthyChecks = 0
+
+    for (let attempt = 0; attempt < 8; attempt++) {
+      // eslint-disable-next-line no-await-in-loop
+      const running = await checkRunningContainers()
+      const missing = requiredServices.filter((service) => !running.some((container) => container.includes(service)))
+
+      if (missing.length === 0) {
+        consecutiveHealthyChecks++
+        // Require two healthy checks in a row so a container that starts and
+        // then exits (e.g. on a failed repo migration) is not reported healthy.
+        if (consecutiveHealthyChecks >= 2) {
+          // eslint-disable-next-line no-await-in-loop
+          const versions = await getContainerVersions()
+          this.logSuccess(`Running IPFS ${versions.ipfs} and IPFS Cluster ${versions.cluster}`)
+          return
+        }
+      } else {
+        consecutiveHealthyChecks = 0
+        this.logInfo(`Waiting for ${missing.join(', ')} to start...`)
       }
+
+      // eslint-disable-next-line no-await-in-loop
+      await delay(5000)
     }
 
-    const versions = await getContainerVersions()
-    this.logSuccess(`Running IPFS ${versions.ipfs} and IPFS Cluster ${versions.cluster}`)
+    throw new Error(
+      'ipfs/cluster containers did not stay running after the update. ' +
+        'Check `docker compose logs`; large repos may still be running a migration.',
+    )
   }
 }

--- a/packages/bgipfs/src/commands/cluster/update/index.ts
+++ b/packages/bgipfs/src/commands/cluster/update/index.ts
@@ -4,38 +4,64 @@ import {promises as fs} from 'node:fs'
 import path from 'node:path'
 
 import {BaseCommand} from '../../../base-command.js'
+import {getBgipfsIpfsConfigPolicy} from '../../../lib/bgipfs-owned-keys.js'
+import {backupIpfsConfig, mergeIpfsConfig, readIpfsConfig, readIpfsRepoVersion, writeIpfsConfig} from '../../../lib/ipfs-config.js'
 import {checkRunningContainers, getContainerVersions} from '../../../lib/system.js'
 import Restart from '../restart/index.js'
 import Start from '../start/index.js'
 
 export default class Update extends BaseCommand {
-  static description = 'Update IPFS and IPFS Cluster to their latest versions'
+  static description = 'Update IPFS, IPFS Cluster, and key cluster dependencies'
 
   static examples = [
     'bgipfs cluster update',
     'bgipfs cluster update --no-backup',
     'bgipfs cluster update --backup-dir ./my-backup',
+    'bgipfs cluster update --ipfs-version v0.39.0 --cluster-version v1.1.6',
   ]
 
   static flags = {
+    'backup-data': Flags.boolean({
+      default: false,
+      description: 'Also back up data/ipfs and data/ipfs-cluster before updating (can be very large)',
+    }),
     'backup-dir': Flags.string({
       description: 'Directory to store backup (defaults to ./backup_YYYYMMDD_HHMMSS)',
+    }),
+    'cluster-version': Flags.string({
+      default: 'v1.1.6',
+      description: 'IPFS Cluster Docker tag to use',
     }),
     force: Flags.boolean({
       char: 'f',
       default: false,
       description: 'Force update: skip confirmation prompts',
     }),
+    'ipfs-version': Flags.string({
+      default: 'v0.41.0',
+      description: 'Kubo Docker tag to use',
+    }),
     'no-backup': Flags.boolean({
       default: false,
       description: 'Skip creating a backup before updating',
     }),
+    'skip-compose-update': Flags.boolean({
+      default: false,
+      description: 'Do not update managed Docker image tags in docker-compose.yml',
+    }),
+    'traefik-version': Flags.string({
+      default: 'v3.6.1',
+      description: 'Traefik Docker tag to use',
+    }),
   }
 
+  // eslint-disable-next-line complexity
   async run(): Promise<void> {
     const {flags} = await this.parse(Update)
 
     try {
+      await this.preflight()
+
       // Check if services are running
       const running = await checkRunningContainers()
       const isRunning = running.length > 0
@@ -49,7 +75,7 @@ export default class Update extends BaseCommand {
   IPFS: ${currentVersions.ipfs}
   IPFS Cluster: ${currentVersions.cluster}`)
         } catch (error) {
-          this.logError(`Failed to get current versions: ${(error as Error).message}`)
+          this.logWarning(`Failed to get current versions: ${(error as Error).message}`)
         }
       }
 
@@ -70,25 +96,54 @@ export default class Update extends BaseCommand {
           flags['backup-dir'] || `backup_${new Date().toISOString().replaceAll(/[.:]/g, '').slice(0, 15)}`
 
         if (flags.force) {
-          await this.createBackup(backupDir)
+          await this.createBackup(backupDir, flags['backup-data'])
         } else {
           const shouldBackup = await this.confirm(
             `Would you like to create a backup before updating? (Will be stored in ${backupDir})`,
           )
           if (shouldBackup) {
-            await this.createBackup(backupDir)
+            await this.createBackup(backupDir, flags['backup-data'])
           } else {
             this.logInfo('Skipping backup')
           }
         }
       }
 
+      const usesConfigBindMount = !flags['skip-compose-update'] && (await this.usesIpfsConfigBindMount())
+      if (!flags['skip-compose-update']) {
+        const ipfsConfigPath = usesConfigBindMount ? 'ipfs.config.json' : await this.getLiveIpfsConfigPath()
+        await this.migrateIpfsConfig(flags['ipfs-version'], ipfsConfigPath)
+      }
+
+      if (usesConfigBindMount) {
+        await this.stageIpfsConfigForUnmountedRepo()
+      }
+
+      const composeChanged = flags['skip-compose-update']
+        ? false
+        : await this.updateManagedImageTags({
+          clusterVersion: flags['cluster-version'],
+          ipfsVersion: flags['ipfs-version'],
+          traefikVersion: flags['traefik-version'],
+        })
+
+      const beforeImages = await this.getComposeImageIds()
+      const beforeRunningImages = isRunning ? await this.getRunningServiceImageIds() : new Map<string, string>()
+
       // Pull latest images first
       this.logInfo('Pulling latest images...')
       await execa('docker', ['compose', 'pull'])
 
+      const afterImages = await this.getComposeImageIds()
+      const afterServiceImages = await this.getComposeServiceImageIds()
+      this.logImageChanges(beforeImages, afterImages)
+      const runningImagesOutdated = isRunning && this.hasRunningImageMismatch(beforeRunningImages, afterServiceImages)
+
       // Check if versions changed
-      if (isRunning && !(await this.checkVersions(currentVersions))) {
+      if (
+        isRunning &&
+        !(await this.checkVersions(currentVersions, beforeImages, afterImages, composeChanged || runningImagesOutdated))
+      ) {
         return
       }
 
@@ -102,6 +157,11 @@ export default class Update extends BaseCommand {
       }
 
       this.logSuccess('IPFS cluster updated successfully')
+      await this.verifyUpdatedCluster()
+      if (usesConfigBindMount) {
+        await this.archiveLegacyIpfsConfig()
+      }
+
       if (!flags['no-backup'] && !flags.force) {
         this.logInfo(`A backup was created in: ${flags['backup-dir'] || 'backup_*'}`)
       }
@@ -113,7 +173,34 @@ export default class Update extends BaseCommand {
     }
   }
 
-  private async checkVersions(currentVersions?: {cluster: string; ipfs: string}): Promise<boolean> {
+  private async archiveLegacyIpfsConfig(): Promise<void> {
+    const legacyPath = 'ipfs.config.json'
+    const hasLegacyConfig = await fs
+      .access(legacyPath)
+      .then(() => true)
+      .catch(() => false)
+
+    if (!hasLegacyConfig) {
+      return
+    }
+
+    const archivePath = `${legacyPath}.legacy-${new Date().toISOString().replaceAll(/[.:]/g, '-')}`
+    await fs.rename(legacyPath, archivePath)
+    this.logInfo(`Archived legacy exported IPFS config to ${archivePath}`)
+    this.logInfo('The live Kubo config is now data/ipfs/config')
+  }
+
+  private async checkVersions(
+    currentVersions?: {cluster: string; ipfs: string},
+    beforeImages?: Map<string, string>,
+    afterImages?: Map<string, string>,
+    restartNeeded = false,
+  ): Promise<boolean> {
+    const imagesChanged =
+      beforeImages &&
+      afterImages &&
+      [...afterImages].some(([image, imageId]) => beforeImages.get(image) && beforeImages.get(image) !== imageId)
+
     try {
       const newVersions = await getContainerVersions()
       if (currentVersions) {
@@ -121,23 +208,29 @@ export default class Update extends BaseCommand {
         const clusterUpdated = newVersions.cluster !== currentVersions.cluster
 
         if (!ipfsUpdated && !clusterUpdated) {
-          this.logInfo('No updates available - already running latest versions')
-          return false
+          if (!imagesChanged && !restartNeeded) {
+            this.logInfo('No updates available - already running latest versions')
+            return false
+          }
+
+          this.logInfo('Restarting to apply updated image configuration')
         }
 
-        this.logInfo(`New versions available:
+        if (ipfsUpdated || clusterUpdated) {
+          this.logInfo(`New versions available:
   IPFS: ${currentVersions.ipfs} -> ${newVersions.ipfs}
   IPFS Cluster: ${currentVersions.cluster} -> ${newVersions.cluster}`)
+        }
       }
 
       return true
     } catch (error) {
-      this.logError(`Failed to check new versions: ${(error as Error).message}`)
+      this.logWarning(`Failed to check new versions: ${(error as Error).message}`)
       return true // Continue with update if version check fails
     }
   }
 
-  private async createBackup(backupDir: string): Promise<void> {
+  private async createBackup(backupDir: string, includeData: boolean): Promise<void> {
     // Check if backup directory exists
     try {
       await fs.access(backupDir)
@@ -150,27 +243,269 @@ export default class Update extends BaseCommand {
     this.logInfo('Creating backup before update...')
     await fs.mkdir(backupDir, {recursive: true})
 
-    // List of files and directories to backup
+    // Large blockstores should be backed up with volume snapshots in production.
     const itemsToBackup = [
-      {dest: 'ipfs', src: 'data/ipfs'},
-      {dest: 'ipfs-cluster', src: 'data/ipfs-cluster'},
-      {dest: 'ipfs.config.json', src: 'ipfs.config.json'},
+      {dest: 'ipfs.config.json', optional: true, src: 'ipfs.config.json'},
+      {dest: 'data/ipfs/config', optional: true, src: 'data/ipfs/config'},
       {dest: 'service.json', src: 'service.json'},
       {dest: 'identity.json', src: 'identity.json'},
       {dest: 'auth', src: 'auth'},
     ]
+    const dataItemsToBackup = [
+      {dest: 'ipfs', src: 'data/ipfs'},
+      {dest: 'ipfs-cluster', src: 'data/ipfs-cluster'},
+    ]
+    const allItemsToBackup = includeData ? [...dataItemsToBackup, ...itemsToBackup] : itemsToBackup
+
+    if (!includeData) {
+      this.logInfo('Skipping data/ipfs and data/ipfs-cluster backup; use --backup-data or an EBS snapshot for data')
+    }
 
     // Copy each item
+    for (const item of allItemsToBackup) {
+      try {
+        this.logInfo(`Backing up ${item.src}...`)
+        // eslint-disable-next-line no-await-in-loop
+        await fs.mkdir(path.dirname(path.join(backupDir, item.dest)), {recursive: true})
+        // eslint-disable-next-line no-await-in-loop
+        await fs.cp(item.src, path.join(backupDir, item.dest), {recursive: true})
+        this.logSuccess(`Successfully backed up ${item.src}`)
+      } catch (error) {
+        if ('optional' in item && item.optional) {
+          this.logInfo(`Skipping missing optional backup item ${item.src}`)
+          continue
+        }
+
+        throw new Error(`Failed to backup ${item.src}: ${(error as Error).message}`)
+      }
+    }
+  }
+
+  private async getComposeImageIds(): Promise<Map<string, string>> {
+    const {stdout} = await execa('docker', ['compose', 'config', '--images'])
+    const images = stdout
+      .split('\n')
+      .map((line) => line.trim())
+      .filter(Boolean)
+
+    const result = new Map<string, string>()
     await Promise.all(
-      itemsToBackup.map(async (item) => {
+      images.map(async (image) => {
         try {
-          this.logInfo(`Backing up ${item.src}...`)
-          await fs.cp(item.src, path.join(backupDir, item.dest), {recursive: true})
-          this.logSuccess(`Successfully backed up ${item.src}`)
-        } catch (error) {
-          this.logError(`Failed to backup ${item.src}: ${(error as Error).message}`)
+          const {stdout: imageId} = await execa('docker', ['image', 'inspect', image, '--format', '{{.Id}}'])
+          result.set(image, imageId.trim())
+        } catch {
+          result.set(image, 'not-present')
         }
       }),
     )
+
+    return result
+  }
+
+  private async getComposeServiceImageIds(): Promise<Map<string, string>> {
+    const {stdout} = await execa('docker', ['compose', 'config', '--format', 'json'])
+    const config = JSON.parse(stdout) as {services: Record<string, {image?: string}>}
+    const serviceImages = new Map<string, string>()
+
+    await Promise.all(
+      Object.entries(config.services).map(async ([service, config]) => {
+        if (!config.image) {
+          return
+        }
+
+        try {
+          const {stdout: imageId} = await execa('docker', ['image', 'inspect', config.image, '--format', '{{.Id}}'])
+          serviceImages.set(service, imageId.trim())
+        } catch {
+          serviceImages.set(service, 'not-present')
+        }
+      }),
+    )
+
+    return serviceImages
+  }
+
+  private async getLiveIpfsConfigPath(): Promise<string> {
+    const repoConfigPath = 'data/ipfs/config'
+    const hasRepoConfig = await fs
+      .access(repoConfigPath)
+      .then(() => true)
+      .catch(() => false)
+
+    return hasRepoConfig ? repoConfigPath : 'ipfs.config.json'
+  }
+
+  private async getRunningServiceImageIds(): Promise<Map<string, string>> {
+    const {stdout} = await execa('docker', ['compose', 'ps', '--format', 'json'])
+    const containers = stdout
+      .split('\n')
+      .map((line) => line.trim())
+      .filter(Boolean)
+      .map((line) => JSON.parse(line) as {ID: string; Service: string})
+
+    const serviceImages = new Map<string, string>()
+    await Promise.all(
+      containers.map(async (container) => {
+        const {stdout: imageId} = await execa('docker', ['inspect', container.ID, '--format', '{{.Image}}'])
+        serviceImages.set(container.Service, imageId.trim())
+      }),
+    )
+
+    return serviceImages
+  }
+
+  private getTargetRepoVersion(ipfsVersion: string): number | undefined {
+    const match = ipfsVersion.match(/^v?(\d+)\.(\d+)\.(\d+)/)
+    if (!match) {
+      return undefined
+    }
+
+    const [, major, minor] = match.map(Number)
+    return major > 0 || minor >= 38 ? 18 : undefined
+  }
+
+  private hasRunningImageMismatch(
+    runningServiceImages: Map<string, string>,
+    desiredServiceImages: Map<string, string>,
+  ): boolean {
+    let hasMismatch = false
+
+    for (const [service, desiredImageId] of desiredServiceImages) {
+      const runningImageId = runningServiceImages.get(service)
+      if (runningImageId && runningImageId !== desiredImageId) {
+        this.logInfo(`${service}: running image differs from compose target`)
+        hasMismatch = true
+      }
+    }
+
+    return hasMismatch
+  }
+
+  private logImageChanges(beforeImages: Map<string, string>, afterImages: Map<string, string>): void {
+    for (const [image, afterId] of afterImages) {
+      const beforeId = beforeImages.get(image)
+      if (!beforeId) {
+        this.logInfo(`${image}: newly tracked`)
+      } else if (beforeId === 'not-present' && afterId !== 'not-present') {
+        this.logSuccess(`${image}: pulled`)
+      } else if (beforeId === afterId) {
+        this.logInfo(`${image}: unchanged`)
+      } else {
+        this.logSuccess(`${image}: updated`)
+      }
+    }
+  }
+
+  private async migrateIpfsConfig(ipfsVersion: string, configPath: string): Promise<void> {
+    const config = await readIpfsConfig(configPath)
+    const repoVersion = this.getTargetRepoVersion(ipfsVersion) ?? (await readIpfsRepoVersion())
+    const policy = getBgipfsIpfsConfigPolicy(config, repoVersion)
+    const migrated = mergeIpfsConfig(config, policy.ownedKeys, policy.removedKeys)
+
+    if (JSON.stringify(config) === JSON.stringify(migrated)) {
+      this.logInfo('IPFS config is already compatible with the target Kubo version')
+      return
+    }
+
+    const backupPath = await backupIpfsConfig(configPath)
+    await writeIpfsConfig(migrated, configPath)
+    this.logSuccess(`Migrated IPFS config for target Kubo version; backup saved to ${backupPath}`)
+  }
+
+  private async preflight(): Promise<void> {
+    await execa('docker', ['compose', 'version'])
+    await fs.access('docker-compose.yml')
+  }
+
+  private removeIpfsConfigBindMount(compose: string): string {
+    return compose
+      .split('\n')
+      .filter((line) => line.trim() !== '- ./ipfs.config.json:/data/ipfs/config:ro')
+      .join('\n')
+  }
+
+  private replaceServiceImage(compose: string, service: string, image: string): string {
+    const lines = compose.split('\n')
+    const servicePattern = new RegExp(`^  ${service}:\\s*$`)
+
+    const serviceStart = lines.findIndex((line) => servicePattern.test(line))
+    if (serviceStart === -1) {
+      throw new Error(`Could not find ${service} service in docker-compose.yml`)
+    }
+
+    for (let index = serviceStart + 1; index < lines.length; index++) {
+      if (/^ {2}[\w-]+:\s*$/.test(lines[index])) {
+        break
+      }
+
+      if (/^ {4}image:\s*/.test(lines[index])) {
+        lines[index] = `    image: ${image}`
+        return lines.join('\n')
+      }
+    }
+
+    throw new Error(`Could not find image for ${service} service in docker-compose.yml`)
+  }
+
+  private async stageIpfsConfigForUnmountedRepo(): Promise<void> {
+    try {
+      await fs.copyFile('ipfs.config.json', 'data/ipfs/config')
+      this.logSuccess('Staged ipfs.config.json into data/ipfs/config')
+    } catch (error) {
+      const nodeError = error as NodeJS.ErrnoException
+      if (nodeError.code !== 'EACCES' && nodeError.code !== 'EPERM') {
+        throw error
+      }
+
+      throw new Error(
+        'Cannot write data/ipfs/config with the current host user. Run this command, then retry the update:\n' +
+          'sudo install -m 0644 -o "$(stat -c %u data/ipfs)" -g "$(stat -c %g data/ipfs)" ipfs.config.json data/ipfs/config',
+      )
+    }
+  }
+
+  private async updateManagedImageTags(versions: {
+    clusterVersion: string
+    ipfsVersion: string
+    traefikVersion: string
+  }): Promise<boolean> {
+    const composePath = 'docker-compose.yml'
+    const original = await fs.readFile(composePath, 'utf8')
+    let updated = original
+
+    updated = this.replaceServiceImage(updated, 'ipfs', `ipfs/kubo:${versions.ipfsVersion}`)
+    updated = this.replaceServiceImage(updated, 'cluster', `ipfs/ipfs-cluster:${versions.clusterVersion}`)
+    updated = this.replaceServiceImage(updated, 'traefik', `traefik:${versions.traefikVersion}`)
+    updated = this.removeIpfsConfigBindMount(updated)
+
+    if (updated === original) {
+      this.logInfo('Docker image tags are already up to date')
+      return false
+    }
+
+    const backupPath = `${composePath}.${new Date().toISOString().replaceAll(/[.:]/g, '-')}.bak`
+    await fs.copyFile(composePath, backupPath)
+    await fs.writeFile(composePath, updated)
+    this.logSuccess(`Updated managed Docker image tags in ${composePath}`)
+    this.logInfo(`Previous compose file saved to ${backupPath}`)
+    return true
+  }
+
+  private async usesIpfsConfigBindMount(): Promise<boolean> {
+    const compose = await fs.readFile('docker-compose.yml', 'utf8')
+    return compose.split('\n').some((line) => line.trim() === '- ./ipfs.config.json:/data/ipfs/config:ro')
+  }
+
+  private async verifyUpdatedCluster(): Promise<void> {
+    const running = await checkRunningContainers()
+    for (const service of ['ipfs', 'cluster']) {
+      if (!running.some((container) => container.includes(service))) {
+        throw new Error(`${service} container is not running after update`)
+      }
+    }
+
+    const versions = await getContainerVersions()
+    this.logSuccess(`Running IPFS ${versions.ipfs} and IPFS Cluster ${versions.cluster}`)
   }
 }

--- a/packages/bgipfs/src/lib/bgipfs-owned-keys.ts
+++ b/packages/bgipfs/src/lib/bgipfs-owned-keys.ts
@@ -21,7 +21,7 @@ export const getBgipfsIpfsConfigPolicy = (
         'Provide.Strategy': 'pinned+entities',
         ...COMMON_OWNED_KEYS,
       },
-      removedKeys: ['Reprovider'],
+      removedKeys: ['Provider', 'Reprovider'],
     }
   }
 

--- a/packages/bgipfs/src/lib/compose-file.ts
+++ b/packages/bgipfs/src/lib/compose-file.ts
@@ -1,0 +1,45 @@
+import {promises as fs} from 'node:fs'
+
+// Volume entry legacy compose files use to mount the exported IPFS config into the Kubo repo.
+export const IPFS_CONFIG_BIND_MOUNT_LINE = '- ./ipfs.config.json:/data/ipfs/config:ro'
+
+const DOCKER_TAG_PATTERN = /^\w[\w.-]{0,127}$/
+
+export const isValidDockerTag = (tag: string): boolean => DOCKER_TAG_PATTERN.test(tag)
+
+export const hasIpfsConfigBindMount = (compose: string): boolean =>
+  compose.split('\n').some((line) => line.trim() === IPFS_CONFIG_BIND_MOUNT_LINE)
+
+export const removeIpfsConfigBindMount = (compose: string): string =>
+  compose
+    .split('\n')
+    .filter((line) => line.trim() !== IPFS_CONFIG_BIND_MOUNT_LINE)
+    .join('\n')
+
+export const usesIpfsConfigBindMount = async (composePath = 'docker-compose.yml'): Promise<boolean> => {
+  const compose = await fs.readFile(composePath, 'utf8').catch(() => '')
+  return hasIpfsConfigBindMount(compose)
+}
+
+export const replaceServiceImage = (compose: string, service: string, image: string): string => {
+  const lines = compose.split('\n')
+  const servicePattern = new RegExp(`^  ${service}:\\s*$`)
+
+  const serviceStart = lines.findIndex((line) => servicePattern.test(line))
+  if (serviceStart === -1) {
+    throw new Error(`Could not find ${service} service in docker-compose.yml`)
+  }
+
+  for (let index = serviceStart + 1; index < lines.length; index++) {
+    if (/^ {2}[\w-]+:\s*$/.test(lines[index])) {
+      break
+    }
+
+    if (/^ {4}image:\s*/.test(lines[index])) {
+      lines[index] = `    image: ${image}`
+      return lines.join('\n')
+    }
+  }
+
+  throw new Error(`Could not find image for ${service} service in docker-compose.yml`)
+}

--- a/packages/bgipfs/src/lib/ipfs-config.ts
+++ b/packages/bgipfs/src/lib/ipfs-config.ts
@@ -1,6 +1,11 @@
 import {promises as fs} from 'node:fs'
 import path from 'node:path'
 
+import {usesIpfsConfigBindMount} from './compose-file.js'
+
+export const LEGACY_IPFS_CONFIG_PATH = 'ipfs.config.json'
+export const REPO_IPFS_CONFIG_PATH = 'data/ipfs/config'
+
 export interface IpfsConfigChange {
   key: string
   nextValue: unknown
@@ -50,7 +55,41 @@ export const mergeIpfsConfig = (
   return merged
 }
 
-export const readIpfsConfig = async (configPath = 'ipfs.config.json'): Promise<Record<string, unknown>> => {
+// The IPFS config file bgipfs should read and write: the Kubo repo config at
+// data/ipfs/config, unless the compose file still bind-mounts the legacy
+// exported ipfs.config.json over it (in which case that file is the live one).
+export const getLiveIpfsConfigPath = async (): Promise<string> => {
+  const hasRepoConfig = await fs
+    .access(REPO_IPFS_CONFIG_PATH)
+    .then(() => true)
+    .catch(() => false)
+
+  if (!hasRepoConfig) {
+    return LEGACY_IPFS_CONFIG_PATH
+  }
+
+  return (await usesIpfsConfigBindMount()) ? LEGACY_IPFS_CONFIG_PATH : REPO_IPFS_CONFIG_PATH
+}
+
+// Repo version the given Kubo release will migrate to. Kubo 0.38 moved to repo
+// version 18; we assume 18 for anything newer (including future majors) since
+// the bgipfs config policy only branches at >= 18. Returns undefined for
+// older releases and non-semver tags like `release`.
+export const getTargetRepoVersion = (ipfsVersion: string): number | undefined => {
+  const match = ipfsVersion.match(/^v?(\d+)\.(\d+)\.(\d+)/)
+  if (!match) {
+    return undefined
+  }
+
+  const [, major, minor] = match.map(Number)
+  return major > 0 || minor >= 38 ? 18 : undefined
+}
+
+export const ipfsConfigWritePermissionHint = (configPath: string): string =>
+  `Cannot write ${configPath} as the current host user. Take ownership of the file and retry:\n` +
+  `sudo chown "$(id -u):$(id -g)" ${configPath}`
+
+export const readIpfsConfig = async (configPath = LEGACY_IPFS_CONFIG_PATH): Promise<Record<string, unknown>> => {
   const content = await fs.readFile(configPath, 'utf8')
   const parsed = JSON.parse(content) as unknown
 
@@ -72,7 +111,7 @@ export const readIpfsRepoVersion = async (versionPath = 'data/ipfs/version'): Pr
 }
 
 export const backupIpfsConfig = async (
-  configPath = 'ipfs.config.json',
+  configPath = LEGACY_IPFS_CONFIG_PATH,
   backupDir = 'config-backup',
 ): Promise<string> => {
   await fs.mkdir(backupDir, {recursive: true})
@@ -84,9 +123,18 @@ export const backupIpfsConfig = async (
 
 export const writeIpfsConfig = async (
   config: Record<string, unknown>,
-  configPath = 'ipfs.config.json',
+  configPath = LEGACY_IPFS_CONFIG_PATH,
 ): Promise<void> => {
-  await fs.writeFile(configPath, JSON.stringify(config, null, 2) + '\n')
+  try {
+    await fs.writeFile(configPath, JSON.stringify(config, null, 2) + '\n')
+  } catch (error) {
+    const {code} = error as NodeJS.ErrnoException
+    if (code === 'EACCES' || code === 'EPERM') {
+      throw new Error(ipfsConfigWritePermissionHint(configPath))
+    }
+
+    throw error
+  }
 }
 
 const getNestedValue = (config: Record<string, unknown>, key: string): unknown => {

--- a/packages/bgipfs/templates/docker-compose.yml
+++ b/packages/bgipfs/templates/docker-compose.yml
@@ -1,18 +1,17 @@
 services:
   ipfs:
     container_name: ipfs
-    image: ipfs/kubo:release
+    image: ipfs/kubo:v0.41.0
     ports:
       - "4001:4001"  # swarm
       - "8080:8080"  # gateway (IP mode only)
       - "127.0.0.1:5001:5001"  # api access from localhost
     volumes:
       - ./data/ipfs:/data/ipfs
-      - ./ipfs.config.json:/data/ipfs/config:ro
 
   cluster:
     container_name: cluster
-    image: ipfs/ipfs-cluster:${IPFS_CLUSTER_VERSION:-latest}
+    image: ipfs/ipfs-cluster:${IPFS_CLUSTER_VERSION:-v1.1.6}
     depends_on:
       - ipfs
     environment:

--- a/packages/bgipfs/templates/init.docker-compose.yml
+++ b/packages/bgipfs/templates/init.docker-compose.yml
@@ -1,14 +1,13 @@
 services:
   init-ipfs:
-    image: ipfs/kubo:release
+    image: ipfs/kubo:v0.41.0
     volumes:
       - ./data/ipfs:/data/ipfs
     command: ["ipfs", "init", "--profile=server"]
 
   cluster:
     container_name: cluster-init
-    # PLACEHOLDER: Update with latest stable version before release
-    image: ipfs/ipfs-cluster:v1.1.2
+    image: ipfs/ipfs-cluster:v1.1.6
     environment:
       CLUSTER_PEERNAME: ${PEERNAME}
       CLUSTER_IPFSHTTP_NODEMULTIADDRESS: /dns4/ipfs/tcp/5001

--- a/packages/bgipfs/test/lib/bgipfs-owned-keys.test.ts
+++ b/packages/bgipfs/test/lib/bgipfs-owned-keys.test.ts
@@ -23,7 +23,7 @@ describe('bgipfs-owned-keys', () => {
     })
   })
 
-  it('uses current Provide keys and removes Reprovider for repo version 18+', () => {
+  it('uses current Provide keys and removes deprecated provider keys for repo version 18+', () => {
     const policy = getBgipfsIpfsConfigPolicy(
       {
         Reprovider: {
@@ -39,7 +39,7 @@ describe('bgipfs-owned-keys', () => {
         'Provide.Strategy': 'pinned+entities',
         'Routing.Type': 'dht',
       },
-      removedKeys: ['Reprovider'],
+      removedKeys: ['Provider', 'Reprovider'],
     })
   })
 
@@ -71,7 +71,7 @@ describe('bgipfs-owned-keys', () => {
         'Provide.Strategy': 'pinned+entities',
         'Routing.Type': 'dht',
       },
-      removedKeys: ['Reprovider'],
+      removedKeys: ['Provider', 'Reprovider'],
     })
   })
 })

--- a/packages/bgipfs/test/lib/compose-file.test.ts
+++ b/packages/bgipfs/test/lib/compose-file.test.ts
@@ -1,0 +1,113 @@
+import {expect} from 'chai'
+
+import {
+  hasIpfsConfigBindMount,
+  isValidDockerTag,
+  removeIpfsConfigBindMount,
+  replaceServiceImage,
+} from '../../src/lib/compose-file.js'
+
+const SAMPLE_COMPOSE = `services:
+  ipfs:
+    container_name: ipfs
+    image: ipfs/kubo:release
+    volumes:
+      - ./data/ipfs:/data/ipfs
+      - ./ipfs.config.json:/data/ipfs/config:ro
+
+  cluster:
+    container_name: cluster
+    image: ipfs/ipfs-cluster:\${IPFS_CLUSTER_VERSION:-latest}
+    volumes:
+      - ./data/ipfs-cluster:/data/ipfs-cluster
+
+  traefik:
+    image: traefik:v3.1
+    ports:
+      - "5555:5555"
+`
+
+describe('compose-file', () => {
+  describe('replaceServiceImage', () => {
+    it('replaces only the named service image', () => {
+      const updated = replaceServiceImage(SAMPLE_COMPOSE, 'ipfs', 'ipfs/kubo:v0.41.0')
+
+      expect(updated).to.include('    image: ipfs/kubo:v0.41.0')
+      expect(updated).to.not.include('ipfs/kubo:release')
+      // eslint-disable-next-line no-template-curly-in-string
+      expect(updated).to.include('image: ipfs/ipfs-cluster:${IPFS_CLUSTER_VERSION:-latest}')
+      expect(updated).to.include('image: traefik:v3.1')
+    })
+
+    it('replaces images for later services', () => {
+      const updated = replaceServiceImage(SAMPLE_COMPOSE, 'traefik', 'traefik:v3.6.1')
+
+      expect(updated).to.include('    image: traefik:v3.6.1')
+      expect(updated).to.include('image: ipfs/kubo:release')
+    })
+
+    it('leaves unrelated lines untouched', () => {
+      const updated = replaceServiceImage(SAMPLE_COMPOSE, 'cluster', 'ipfs/ipfs-cluster:v1.1.6')
+
+      expect(updated.split('\n')).to.have.length(SAMPLE_COMPOSE.split('\n').length)
+      expect(updated).to.include('      - ./data/ipfs-cluster:/data/ipfs-cluster')
+    })
+
+    it('throws when the service is missing', () => {
+      expect(() => replaceServiceImage(SAMPLE_COMPOSE, 'nginx', 'nginx:latest')).to.throw(
+        'Could not find nginx service',
+      )
+    })
+
+    it('throws when the service has no image line', () => {
+      const compose = `services:\n  ipfs:\n    container_name: ipfs\n  cluster:\n    image: ipfs/ipfs-cluster:v1.1.6\n`
+      expect(() => replaceServiceImage(compose, 'ipfs', 'ipfs/kubo:v0.41.0')).to.throw(
+        'Could not find image for ipfs service',
+      )
+    })
+  })
+
+  describe('removeIpfsConfigBindMount', () => {
+    it('removes the legacy bind mount line only', () => {
+      const updated = removeIpfsConfigBindMount(SAMPLE_COMPOSE)
+
+      expect(updated).to.not.include('ipfs.config.json')
+      expect(updated).to.include('      - ./data/ipfs:/data/ipfs')
+      expect(updated.split('\n')).to.have.length(SAMPLE_COMPOSE.split('\n').length - 1)
+    })
+
+    it('is a no-op when the bind mount is absent', () => {
+      const compose = removeIpfsConfigBindMount(SAMPLE_COMPOSE)
+      expect(removeIpfsConfigBindMount(compose)).to.equal(compose)
+    })
+  })
+
+  describe('hasIpfsConfigBindMount', () => {
+    it('detects the bind mount regardless of indentation', () => {
+      expect(hasIpfsConfigBindMount(SAMPLE_COMPOSE)).to.equal(true)
+      expect(hasIpfsConfigBindMount('  - ./ipfs.config.json:/data/ipfs/config:ro\n')).to.equal(true)
+    })
+
+    it('returns false when absent', () => {
+      expect(hasIpfsConfigBindMount(removeIpfsConfigBindMount(SAMPLE_COMPOSE))).to.equal(false)
+      expect(hasIpfsConfigBindMount('')).to.equal(false)
+    })
+  })
+
+  describe('isValidDockerTag', () => {
+    it('accepts common tags', () => {
+      expect(isValidDockerTag('v0.41.0')).to.equal(true)
+      expect(isValidDockerTag('1.1.6')).to.equal(true)
+      expect(isValidDockerTag('latest')).to.equal(true)
+      expect(isValidDockerTag('v0.41.0-rc1')).to.equal(true)
+    })
+
+    it('rejects malformed tags', () => {
+      expect(isValidDockerTag('')).to.equal(false)
+      expect(isValidDockerTag('v1 latest')).to.equal(false)
+      expect(isValidDockerTag('v1\n    privileged: true')).to.equal(false)
+      expect(isValidDockerTag('.hidden')).to.equal(false)
+      expect(isValidDockerTag('-leading-dash')).to.equal(false)
+    })
+  })
+})

--- a/packages/bgipfs/test/lib/ipfs-config.test.ts
+++ b/packages/bgipfs/test/lib/ipfs-config.test.ts
@@ -1,11 +1,12 @@
 import {expect} from 'chai'
-import {mkdtemp, readFile, readdir, rm, writeFile} from 'node:fs/promises'
+import {chmod, mkdtemp, readFile, readdir, rm, writeFile} from 'node:fs/promises'
 import {tmpdir} from 'node:os'
 import path from 'node:path'
 
 import {
   backupIpfsConfig,
   computeIpfsConfigChanges,
+  getTargetRepoVersion,
   mergeIpfsConfig,
   readIpfsConfig,
   readIpfsRepoVersion,
@@ -326,5 +327,33 @@ describe('ipfs-config', () => {
 
     expect(await readIpfsRepoVersion(versionPath)).to.equal(undefined)
     expect(await readIpfsRepoVersion(path.join(workdir, 'missing'))).to.equal(undefined)
+  })
+
+  it('maps Kubo versions to their target repo version', () => {
+    expect(getTargetRepoVersion('v0.41.0')).to.equal(18)
+    expect(getTargetRepoVersion('0.38.0')).to.equal(18)
+    expect(getTargetRepoVersion('v0.41.0-rc1')).to.equal(18)
+    expect(getTargetRepoVersion('v1.0.0')).to.equal(18)
+    expect(getTargetRepoVersion('v0.37.9')).to.equal(undefined)
+    expect(getTargetRepoVersion('release')).to.equal(undefined)
+    expect(getTargetRepoVersion('latest')).to.equal(undefined)
+  })
+
+  it('reports a permission hint when the config is not writable', async function () {
+    if (process.getuid?.() === 0) {
+      this.skip()
+    }
+
+    const configPath = path.join(workdir, 'config')
+    await writeFile(configPath, '{}\n')
+    await chmod(configPath, 0o444)
+
+    try {
+      await writeIpfsConfig({Routing: {Type: 'dht'}}, configPath)
+      expect.fail('expected writeIpfsConfig to throw')
+    } catch (error) {
+      expect((error as Error).message).to.include('sudo chown')
+      expect((error as Error).message).to.include(configPath)
+    }
   })
 })


### PR DESCRIPTION
## Summary
- Pin new bgipfs cluster templates to Kubo v0.41.0 and IPFS Cluster v1.1.6
- Expand `bgipfs cluster update` to migrate managed image tags, remove the old read-only Kubo config bind mount, pull images, restart when needed, and verify versions
- Migrate modern Kubo config by removing deprecated Provider/Reprovider keys

## Testing
- `pnpm --filter bgipfs test -- --reporter spec`
- Full local E2E:
  - reset cluster/config and removed Docker runtime state
  - initialized via bgipfs CLI with local compose patched to `ipfs/kubo:v0.32.1`
  - verified pre-upgrade upload, gateway fetch, and cluster pin status
  - ran `bgipfs cluster update --force`
  - verified Kubo `0.41.0`, IPFS Cluster `1.1.6`, repo version `18`, pre-upgrade pin still pinned, and post-upgrade upload pinned
